### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/format-check.yaml
+++ b/.github/workflows/format-check.yaml
@@ -5,6 +5,9 @@ on:
     branches:
       - "*"
 
+permissions:
+  contents: read
+
 jobs:
   format-check:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -4,6 +4,9 @@ on:
     branches:
       - "*"
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/flixlix/flixlix-cards/security/code-scanning/2](https://github.com/flixlix/flixlix-cards/security/code-scanning/2)

Add an explicit `permissions` block in `.github/workflows/test.yaml` at the workflow root so it applies to all jobs by default. For this workflow, the minimal required permission is `contents: read` (needed for checkout and reading repository content). This does not change functionality but enforces least privilege and satisfies CodeQL.

Best single fix:
- Edit `.github/workflows/test.yaml`.
- Insert after the `on:` trigger block (before `jobs:`):
  - `permissions:`
  - `  contents: read`

No imports, methods, or extra definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
