### PR TITLE
fix: :bug: support es2020 targets for older devices

### DIFF
--- a/.changeset/major-pans-spend.md
+++ b/.changeset/major-pans-spend.md
@@ -1,0 +1,7 @@
+---
+"@flixlix-cards/bundler": patch
+"energy-flow-card-plus": patch
+"power-flow-card-plus": patch
+---
+
+fix support for older browsers by targeting es2020 in the final bundle

--- a/packages/tooling/bundler/index.js
+++ b/packages/tooling/bundler/index.js
@@ -47,6 +47,7 @@ export function createCardConfig(options) {
         ignoreDeprecations: "6.0",
         compilerOptions: {
           rootDir: "../..",
+          target: "es2020",
         },
         filterRoot: false,
         include: ["**/*.ts", "**/*.tsx", "../../shared/src/**/*.ts", "../../shared/src/**/*.tsx"],
@@ -57,8 +58,18 @@ export function createCardConfig(options) {
       ...(babelPlugin
         ? [
             babelPlugin({
-              exclude: "node_modules/**",
               babelHelpers: "bundled",
+              exclude: [/node_modules\/@mdi/],
+              presets: [
+                [
+                  "@babel/preset-env",
+                  {
+                    targets: "iOS >= 15, Safari >= 15, Chrome >= 80, Firefox >= 80",
+                    bugfixes: true,
+                    modules: false,
+                  },
+                ],
+              ],
             }),
           ]
         : []),

--- a/packages/tooling/bundler/package.json
+++ b/packages/tooling/bundler/package.json
@@ -10,6 +10,8 @@
     "clean": "rimraf dist node_modules"
   },
   "dependencies": {
+    "@babel/core": "^7.29.0",
+    "@babel/preset-env": "^7.29.2",
     "@rollup/plugin-babel": "^5.3.1",
     "@rollup/plugin-commonjs": "^21.1.0",
     "@rollup/plugin-json": "^4.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -465,6 +465,12 @@ importers:
 
   packages/tooling/bundler:
     dependencies:
+      '@babel/core':
+        specifier: ^7.29.0
+        version: 7.29.0
+      '@babel/preset-env':
+        specifier: ^7.29.2
+        version: 7.29.2(@babel/core@7.29.0)
       '@rollup/plugin-babel':
         specifier: ^5.3.1
         version: 5.3.1(@babel/core@7.29.0)(@types/babel__core@7.20.5)(rollup@2.80.0)


### PR DESCRIPTION
add support for older devices by downtranspiling code to target es2020 instead of current es.
this removes nullish operators, like `??` and `static` occurences in the final bundled js code.