### PR TITLE
fix: :bug: handle negative flows in tolerance helpers

### DIFF
--- a/.changeset/fix-negative-flow-tolerance.md
+++ b/.changeset/fix-negative-flow-tolerance.md
@@ -1,0 +1,6 @@
+---
+"power-flow-card-plus": patch
+"energy-flow-card-plus": patch
+---
+
+Fix: individual devices with negative readings are no longer hidden when display_zero is off

--- a/packages/shared/__tests__/tolerance.test.ts
+++ b/packages/shared/__tests__/tolerance.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from "vitest";
+
+import { hasIndividualObject } from "../src/states/raw/individual/has-individual-object";
+import { adjustZeroTolerance, isAboveTolerance } from "../src/states/tolerance/base";
+
+describe("adjustZeroTolerance", () => {
+  test("null input returns 0", () => {
+    expect(adjustZeroTolerance(null, 5)).toBe(0);
+  });
+
+  test("zero input returns 0", () => {
+    expect(adjustZeroTolerance(0, 5)).toBe(0);
+  });
+
+  test("positive below tolerance returns 0", () => {
+    expect(adjustZeroTolerance(0.5, 5)).toBe(0);
+  });
+
+  test("positive at/above tolerance returns value", () => {
+    expect(adjustZeroTolerance(7, 5)).toBe(7);
+  });
+
+  test("no tolerance returns value unchanged", () => {
+    expect(adjustZeroTolerance(7, undefined)).toBe(7);
+  });
+
+  test("negative above tolerance (regression: should return -50, not 0)", () => {
+    expect(adjustZeroTolerance(-50, 5)).toBe(-50);
+  });
+
+  test("negative below tolerance returns 0", () => {
+    expect(adjustZeroTolerance(-0.5, 5)).toBe(0);
+  });
+});
+
+describe("isAboveTolerance", () => {
+  test("zero value returns false", () => {
+    expect(isAboveTolerance(0, 0)).toBe(false);
+  });
+
+  test("negative value above tolerance magnitude (regression: should return true)", () => {
+    expect(isAboveTolerance(-50, 0)).toBe(true);
+  });
+});
+
+describe("hasIndividualObject", () => {
+  test("negative state above tolerance is visible (user-visible bug regression)", () => {
+    expect(hasIndividualObject(false, -50, 0)).toBe(true);
+  });
+});

--- a/packages/shared/src/states/tolerance/base.ts
+++ b/packages/shared/src/states/tolerance/base.ts
@@ -1,5 +1,5 @@
 export const isAboveTolerance = (value: number | null, tolerance: number): boolean =>
-  !!value && value >= tolerance;
+  value !== null && value !== 0 && Math.abs(value) >= tolerance;
 
 export const adjustZeroTolerance = (
   value: number | null,


### PR DESCRIPTION
Plan 001. Fixes negative-flow handling in the zero-tolerance helpers (`adjustZeroTolerance` was zeroing legitimate negative values via the wrong comparison).

**Reviewed:** pre-existing approved work; dependency of #004/#005.
Changeset: included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)