### PR TITLE
perf: :zap: skip renderData recompute when no card entity changed

### DIFF
--- a/.changeset/perf-skip-recompute-no-entity-change.md
+++ b/.changeset/perf-skip-recompute-no-entity-change.md
@@ -1,0 +1,6 @@
+---
+"power-flow-card-plus": patch
+"energy-flow-card-plus": patch
+---
+
+Perf: skip render-data recomputation when an update touches no configured entity

--- a/packages/flixlix-cards/energy-flow-card-plus/src/energy-flow-card-plus.ts
+++ b/packages/flixlix-cards/energy-flow-card-plus/src/energy-flow-card-plus.ts
@@ -53,6 +53,7 @@ import {
   type TemplatesObj,
 } from "@flixlix-cards/shared/types";
 import { checkShouldShowDots } from "@flixlix-cards/shared/utils/check-should-show-dots";
+import { collectConfigEntityIds } from "@flixlix-cards/shared/utils/collect-config-entity-ids";
 import { computeEnergyDistribution } from "@flixlix-cards/shared/utils/compute-energy-distribution";
 import {
   computeFieldIcon,
@@ -70,6 +71,7 @@ import {
 import { displayValue } from "@flixlix-cards/shared/utils/display-value";
 import { defaultValues, getDefaultConfig } from "@flixlix-cards/shared/utils/get-default-config";
 import { getEnergyEntityState } from "@flixlix-cards/shared/utils/get-energy-entity-state";
+import { hasRelevantStatesChanged } from "@flixlix-cards/shared/utils/has-relevant-states-changed";
 import { registerCustomCard } from "@flixlix-cards/shared/utils/register-custom-card";
 import { sortIndividualObjects } from "@flixlix-cards/shared/utils/sort-individual-objects";
 import { coerceNumber } from "@flixlix-cards/shared/utils/utils";
@@ -703,8 +705,15 @@ export class EnergyFlowCardPlus extends LitElement {
     if (changedProps.has("_config")) {
       void this._refreshEnergyData();
     }
+    const hassChanged =
+      changedProps.has("hass") &&
+      hasRelevantStatesChanged(
+        changedProps.get("hass"),
+        this.hass,
+        collectConfigEntityIds(this._config.entities)
+      );
     if (
-      changedProps.has("hass") ||
+      hassChanged ||
       changedProps.has("_config") ||
       changedProps.has("_templateResults") ||
       changedProps.has("_width") ||

--- a/packages/flixlix-cards/power-flow-card-plus/src/power-flow-card-plus.ts
+++ b/packages/flixlix-cards/power-flow-card-plus/src/power-flow-card-plus.ts
@@ -52,6 +52,7 @@ import {
   type TemplatesObj,
 } from "@flixlix-cards/shared/types";
 import { checkShouldShowDots } from "@flixlix-cards/shared/utils/check-should-show-dots";
+import { collectConfigEntityIds } from "@flixlix-cards/shared/utils/collect-config-entity-ids";
 import {
   computeFieldIcon,
   computeFieldName,
@@ -68,6 +69,7 @@ import {
 import { computePowerDistributionAfterSolarAndBattery } from "@flixlix-cards/shared/utils/compute-power-distribution";
 import { displayValue } from "@flixlix-cards/shared/utils/display-value";
 import { defaultValues, getDefaultConfig } from "@flixlix-cards/shared/utils/get-default-config";
+import { hasRelevantStatesChanged } from "@flixlix-cards/shared/utils/has-relevant-states-changed";
 import { registerCustomCard } from "@flixlix-cards/shared/utils/register-custom-card";
 import { sortIndividualObjects } from "@flixlix-cards/shared/utils/sort-individual-objects";
 import { coerceNumber } from "@flixlix-cards/shared/utils/utils";
@@ -536,8 +538,15 @@ export class PowerFlowCardPlus extends LitElement {
     if (!this._config || !this.hass) {
       return;
     }
+    const hassChanged =
+      changedProps.has("hass") &&
+      hasRelevantStatesChanged(
+        changedProps.get("hass"),
+        this.hass,
+        collectConfigEntityIds(this._config.entities)
+      );
     if (
-      changedProps.has("hass") ||
+      hassChanged ||
       changedProps.has("_config") ||
       changedProps.has("_templateResults") ||
       changedProps.has("_width") ||

--- a/packages/shared/__tests__/relevant-states.test.ts
+++ b/packages/shared/__tests__/relevant-states.test.ts
@@ -1,0 +1,192 @@
+import { describe, expect, test } from "vitest";
+
+import { type ConfigEntities } from "../src/types";
+import { collectConfigEntityIds } from "../src/utils/collect-config-entity-ids";
+import {
+  hasRelevantStatesChanged,
+  type MinimalHass,
+} from "../src/utils/has-relevant-states-changed";
+
+// ---------------------------------------------------------------------------
+// collectConfigEntityIds
+// ---------------------------------------------------------------------------
+
+describe("collectConfigEntityIds", () => {
+  test("full config with ComboEntity grid, secondaries, and multiple individuals", () => {
+    const entities: ConfigEntities = {
+      grid: {
+        entity: { consumption: "sensor.grid_in", production: "sensor.grid_out" },
+        secondary_info: { entity: "sensor.grid_secondary" },
+        color_circle: "color_dynamically",
+        power_outage: {
+          entity: "binary_sensor.grid_outage",
+          entity_generator: "sensor.generator",
+        },
+      },
+      solar: {
+        entity: "sensor.solar",
+        secondary_info: { entity: "sensor.solar_secondary" },
+      },
+      battery: {
+        entity: "sensor.battery",
+        state_of_charge: "sensor.battery_soc",
+        color_circle: "color_dynamically",
+      },
+      home: {
+        entity: "sensor.home",
+        secondary_info: { entity: "sensor.home_secondary" },
+      },
+      fossil_fuel_percentage: {
+        entity: "sensor.fossil",
+        secondary_info: { entity: "sensor.fossil_secondary" },
+      },
+      individual: [
+        {
+          entity: "sensor.individual1",
+          secondary_info: { entity: "sensor.individual1_secondary" },
+        },
+        {
+          entity: "sensor.individual2",
+          // no secondary
+        },
+      ],
+    };
+
+    const ids = collectConfigEntityIds(entities);
+
+    const expected = [
+      "sensor.grid_in",
+      "sensor.grid_out",
+      "sensor.grid_secondary",
+      "binary_sensor.grid_outage",
+      "sensor.generator",
+      "sensor.solar",
+      "sensor.solar_secondary",
+      "sensor.battery",
+      "sensor.battery_soc",
+      "sensor.home",
+      "sensor.home_secondary",
+      "sensor.fossil",
+      "sensor.fossil_secondary",
+      "sensor.individual1",
+      "sensor.individual1_secondary",
+      "sensor.individual2",
+    ];
+
+    // Every expected ID must be present
+    for (const id of expected) {
+      expect(ids).toContain(id);
+    }
+
+    // No extras beyond what we expect
+    expect(ids).toHaveLength(expected.length);
+  });
+
+  test("minimal config returns only configured entity IDs", () => {
+    const entities: ConfigEntities = {
+      solar: { entity: "sensor.solar" },
+    };
+    const ids = collectConfigEntityIds(entities);
+    expect(ids).toEqual(["sensor.solar"]);
+  });
+
+  test("no duplicates when the same entity appears multiple times", () => {
+    const entities: ConfigEntities = {
+      grid: {
+        entity: "sensor.shared",
+        secondary_info: { entity: "sensor.shared" },
+        color_circle: "color_dynamically",
+        power_outage: { entity: "sensor.shared" },
+      },
+    };
+    const ids = collectConfigEntityIds(entities);
+    expect(ids.filter((id) => id === "sensor.shared")).toHaveLength(1);
+  });
+
+  test("empty entities returns empty array", () => {
+    expect(collectConfigEntityIds({})).toEqual([]);
+  });
+
+  test("individual1 / individual2 legacy fields are collected", () => {
+    const entities: ConfigEntities = {
+      individual1: [{ entity: "sensor.ind1" }],
+      individual2: [{ entity: "sensor.ind2" }],
+    };
+    const ids = collectConfigEntityIds(entities);
+    expect(ids).toContain("sensor.ind1");
+    expect(ids).toContain("sensor.ind2");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// hasRelevantStatesChanged
+// ---------------------------------------------------------------------------
+
+const makeHass = (
+  states: Record<string, unknown>,
+  locale?: unknown,
+  themes?: unknown
+): MinimalHass => ({ states, locale, themes });
+
+const stateA = { state: "on" };
+const stateB = { state: "on" }; // different object reference, same value
+const stateC = { state: "on" }; // yet another
+
+describe("hasRelevantStatesChanged", () => {
+  test("returns false when the same hass object (no entity changes)", () => {
+    const hass = makeHass({ "sensor.a": stateA });
+    expect(hasRelevantStatesChanged(hass, hass, ["sensor.a"])).toBe(false);
+  });
+
+  test("returns false when new hass has same state references for watched entities", () => {
+    const oldHass = makeHass({ "sensor.a": stateA, "sensor.irrelevant": stateB });
+    const newHass = makeHass({ "sensor.a": stateA, "sensor.irrelevant": stateC });
+    // "sensor.irrelevant" changed but is not in entityIds
+    expect(hasRelevantStatesChanged(oldHass, newHass, ["sensor.a"])).toBe(false);
+  });
+
+  test("returns true when a relevant state object is replaced", () => {
+    const oldHass = makeHass({ "sensor.a": stateA });
+    const newHass = makeHass({ "sensor.a": stateB }); // different reference
+    expect(hasRelevantStatesChanged(oldHass, newHass, ["sensor.a"])).toBe(true);
+  });
+
+  test("returns false when only an irrelevant entity changed", () => {
+    const oldHass = makeHass({ "sensor.a": stateA, "sensor.b": stateA });
+    const newHass = makeHass({ "sensor.a": stateA, "sensor.b": stateB });
+    expect(hasRelevantStatesChanged(oldHass, newHass, ["sensor.a"])).toBe(false);
+  });
+
+  test("returns true when oldHass is undefined", () => {
+    const newHass = makeHass({ "sensor.a": stateA });
+    expect(hasRelevantStatesChanged(undefined, newHass, ["sensor.a"])).toBe(true);
+  });
+
+  test("returns true when locale reference changed", () => {
+    const localeA = { language: "en" };
+    const localeB = { language: "de" };
+    const oldHass = makeHass({}, localeA);
+    const newHass = makeHass({}, localeB);
+    expect(hasRelevantStatesChanged(oldHass, newHass, [])).toBe(true);
+  });
+
+  test("returns false when locale object is the same reference", () => {
+    const locale = { language: "en" };
+    const oldHass = makeHass({}, locale);
+    const newHass = makeHass({}, locale);
+    expect(hasRelevantStatesChanged(oldHass, newHass, [])).toBe(false);
+  });
+
+  test("returns true when themes reference changed", () => {
+    const themesA = {};
+    const themesB = {};
+    const oldHass = makeHass({}, undefined, themesA);
+    const newHass = makeHass({}, undefined, themesB);
+    expect(hasRelevantStatesChanged(oldHass, newHass, [])).toBe(true);
+  });
+
+  test("returns false when entityIds is empty and no locale/themes changes", () => {
+    const hass = makeHass({ "sensor.a": stateA });
+    expect(hasRelevantStatesChanged(hass, hass, [])).toBe(false);
+  });
+});

--- a/packages/shared/src/utils/collect-config-entity-ids.ts
+++ b/packages/shared/src/utils/collect-config-entity-ids.ts
@@ -1,0 +1,78 @@
+import { type ConfigEntities } from "../types";
+
+/**
+ * Walk all sections of a card's `entities` config and return a deduplicated
+ * array of entity IDs that the card's render output depends on.
+ *
+ * Handles the dual forms of `entity`:
+ *   - string literal  →  "sensor.grid_power"
+ *   - ComboEntity     →  { consumption: "sensor.grid_in", production: "sensor.grid_out" }
+ *
+ * Also collects `secondary_info.entity` and Grid `power_outage` entity refs.
+ */
+export function collectConfigEntityIds(entities: ConfigEntities): string[] {
+  const ids = new Set<string>();
+
+  const add = (id: string | undefined) => {
+    if (id) ids.add(id);
+  };
+
+  const addEntityField = (
+    entity: string | { consumption?: string; production?: string } | undefined
+  ) => {
+    if (!entity) return;
+    if (typeof entity === "string") {
+      add(entity);
+    } else {
+      add(entity.consumption);
+      add(entity.production);
+    }
+  };
+
+  // grid
+  if (entities.grid) {
+    addEntityField(entities.grid.entity);
+    add(entities.grid.secondary_info?.entity);
+    add(entities.grid.power_outage?.entity);
+    add(entities.grid.power_outage?.entity_generator);
+  }
+
+  // solar
+  if (entities.solar) {
+    addEntityField(entities.solar.entity);
+    add(entities.solar.secondary_info?.entity);
+  }
+
+  // battery
+  if (entities.battery) {
+    addEntityField(entities.battery.entity);
+    add(entities.battery.state_of_charge);
+    add(entities.battery.secondary_info?.entity);
+  }
+
+  // home
+  if (entities.home) {
+    addEntityField(entities.home.entity);
+    add(entities.home.secondary_info?.entity);
+  }
+
+  // fossil_fuel_percentage
+  if (entities.fossil_fuel_percentage) {
+    addEntityField(entities.fossil_fuel_percentage.entity);
+    add(entities.fossil_fuel_percentage.secondary_info?.entity);
+  }
+
+  // individual (array) — also handle legacy individual1/individual2 shapes
+  const individualArrays = [entities.individual, entities.individual1, entities.individual2];
+
+  for (const arr of individualArrays) {
+    if (Array.isArray(arr)) {
+      for (const device of arr) {
+        addEntityField(device.entity);
+        add(device.secondary_info?.entity);
+      }
+    }
+  }
+
+  return Array.from(ids);
+}

--- a/packages/shared/src/utils/has-relevant-states-changed.ts
+++ b/packages/shared/src/utils/has-relevant-states-changed.ts
@@ -1,0 +1,38 @@
+/**
+ * Lightweight hass-change guard.
+ *
+ * Structural parameter types keep this dependency-free and easy to unit-test
+ * without importing HomeAssistant.
+ */
+export type MinimalHass = {
+  states: Record<string, unknown>;
+  locale?: unknown;
+  themes?: unknown;
+};
+
+/**
+ * Returns `true` when any of the following is true:
+ * - `oldHass` is `undefined` (initial render — always recompute)
+ * - `oldHass.locale !== newHass.locale` (locale changed → display strings change)
+ * - `oldHass.themes !== newHass.themes` (theme changed → colours change)
+ * - Any entity in `entityIds` has a different state object reference
+ *   (`oldHass.states[id] !== newHass.states[id]`).
+ *
+ * HA state objects are immutable, so reference inequality is the canonical
+ * "this entity changed" check.
+ */
+export function hasRelevantStatesChanged(
+  oldHass: MinimalHass | undefined,
+  newHass: MinimalHass,
+  entityIds: string[]
+): boolean {
+  if (oldHass === undefined) return true;
+  if (oldHass.locale !== newHass.locale) return true;
+  if (oldHass.themes !== newHass.themes) return true;
+
+  for (const id of entityIds) {
+    if (oldHass.states[id] !== newHass.states[id]) return true;
+  }
+
+  return false;
+}


### PR DESCRIPTION
Plan 005. Guards `willUpdate` so the cards only recompute when a *configured* entity (or locale/themes) actually changed — HA swaps `hass` on every state change in the install.

**Reviewed:** 78 shared + 10/10 card tests pass; `willUpdate`-only edits; new shared utils + tests.

> ⛓️ **Stacked on #004 → #001.** Merge order: 001 → 004 → 005.

🤖 Generated with [Claude Code](https://claude.com/claude-code)