### PR TITLE
refactor: :recycle: extract shared BaseCardEditor (flow cards)

### DIFF
--- a/.changeset/extract-shared-editor-base.md
+++ b/.changeset/extract-shared-editor-base.md
@@ -1,0 +1,6 @@
+---
+"power-flow-card-plus": patch
+"energy-flow-card-plus": patch
+---
+
+Refactor: shared editor base class (no behavior change)

--- a/.changeset/fix-negative-flow-tolerance.md
+++ b/.changeset/fix-negative-flow-tolerance.md
@@ -1,0 +1,6 @@
+---
+"power-flow-card-plus": patch
+"energy-flow-card-plus": patch
+---
+
+Fix: individual devices with negative readings are no longer hidden when display_zero is off

--- a/.changeset/remove-duplicate-lit2-from-bundles.md
+++ b/.changeset/remove-duplicate-lit2-from-bundles.md
@@ -1,0 +1,8 @@
+---
+"power-flow-card-plus": patch
+"energy-flow-card-plus": patch
+"energy-breakdown-card": patch
+"sortable-list-card": patch
+---
+
+Remove duplicate Lit 2 runtime from bundles

--- a/packages/flixlix-cards/energy-flow-card-plus/__tests__/render.test.ts
+++ b/packages/flixlix-cards/energy-flow-card-plus/__tests__/render.test.ts
@@ -5,12 +5,75 @@ import { describe, expect, test } from "vitest";
 import { type EnergyFlowCardPlusConfig } from "@flixlix-cards/shared/types";
 import { EnergyFlowCardPlus } from "../src/energy-flow-card-plus";
 
-describe("render", () => {
-  (globalThis as any).ResizeObserver = class {
-    observe() {}
-    disconnect() {}
-  };
+// jsdom does not provide ResizeObserver; stub it so the card's `updated` hook doesn't throw
+(globalThis as any).ResizeObserver = class {
+  observe() {}
+  disconnect() {}
+  unobserve() {}
+};
 
+type HassState = { state: string; attributes: Record<string, unknown> };
+
+function makeHass(states: Record<string, string> = {}) {
+  const hassStates: Record<string, HassState> = {};
+  for (const [entityId, state] of Object.entries(states)) {
+    hassStates[entityId] = {
+      state,
+      attributes: { friendly_name: entityId, unit_of_measurement: "Wh" },
+    };
+  }
+  return {
+    localize: (key: string) => key,
+    locale: { language: "en", number_format: "comma_decimal" },
+    states: hassStates,
+    config: {},
+    user: { name: "test" },
+    connection: {},
+    callWS: async () => ({}),
+  } as any;
+}
+
+function makeCard(config: EnergyFlowCardPlusConfig, hass: ReturnType<typeof makeHass>) {
+  const card = new EnergyFlowCardPlus();
+  card.hass = hass;
+  card.setConfig(config);
+  card.connectedCallback();
+  return card as unknown as {
+    render: () => unknown;
+    _computeRenderData: () => {
+      grid: {
+        has: boolean;
+        state: {
+          fromGrid: number | null;
+          toGrid: number | null;
+          toBattery: number | null;
+          toHome: number | null;
+        };
+      };
+      solar: {
+        has: boolean;
+        state: {
+          total: number | null;
+          toHome: number | null;
+          toGrid: number | null;
+          toBattery: number | null;
+        };
+      };
+      battery: {
+        has: boolean | string;
+        state: {
+          fromBattery: number | null;
+          toBattery: number | null;
+          toGrid: number | null;
+          toHome: number | null;
+        };
+      };
+      individualObjs: Array<{ has: boolean; state: number | null }>;
+    };
+  };
+}
+
+describe("render", () => {
   const hass = {
     localize: (key: string) => key,
     states: {},
@@ -60,5 +123,80 @@ describe("render", () => {
     card.hass = hass;
     card.setConfig(config);
     expect((card as any)._energyCollectionKey).toBe("energy_living_room");
+  });
+});
+
+describe("_computeRenderData (energy card)", () => {
+  test("case 1: basic grid + solar split with known totals", () => {
+    // energy_date_selection: false → reads directly from hass.states (no growthMap needed)
+    const config = {
+      type: "custom:energy-flow-card-plus",
+      energy_date_selection: false,
+      entities: {
+        grid: { entity: "sensor.grid_energy" },
+        solar: { entity: "sensor.solar_energy" },
+      },
+    } as EnergyFlowCardPlusConfig;
+    const hass = makeHass({
+      "sensor.grid_energy": "300",
+      "sensor.solar_energy": "700",
+    });
+    const card = makeCard(config, hass);
+    const data = card._computeRenderData();
+
+    // Grid string entity → fromGrid uses getEnergyEntityStateLocal(entity), toGrid = 0
+    expect(data.grid.state.fromGrid).toBe(300);
+    expect(data.grid.state.toGrid).toBe(0);
+    // Solar total
+    expect(data.solar.state.total).toBe(700);
+    // Solar covers home: toHome = total - toGrid - toBattery = 700 - 0 - 0 = 700
+    expect(data.solar.state.toHome).toBe(700);
+    // Grid toHome = max(fromGrid - toBattery, 0) = max(300 - 0, 0) = 300
+    expect(data.grid.state.toHome).toBe(300);
+  });
+
+  test("case 2: tolerance zeroing via adjustZeroTolerance — grid below tolerance is zeroed", () => {
+    const config = {
+      type: "custom:energy-flow-card-plus",
+      energy_date_selection: false,
+      entities: {
+        grid: { entity: "sensor.grid_energy", display_zero_tolerance: 10 } as any,
+      },
+    } as EnergyFlowCardPlusConfig;
+    // 7Wh is below the 10Wh tolerance
+    const hass = makeHass({ "sensor.grid_energy": "7" });
+    const card = makeCard(config, hass);
+    const data = card._computeRenderData();
+
+    expect(data.grid.state.fromGrid).toBe(0);
+    // Dependency rule: fromGrid === 0 → toHome and toBattery also 0
+    expect(data.grid.state.toHome).toBe(0);
+    expect(data.grid.state.toBattery).toBe(0);
+  });
+
+  test("case 3: no-NaN guarantee — unavailable entity produces only numeric output", () => {
+    const config = {
+      type: "custom:energy-flow-card-plus",
+      energy_date_selection: false,
+      entities: {
+        grid: { entity: "sensor.grid_energy" },
+        solar: { entity: "sensor.solar_energy" },
+      },
+    } as EnergyFlowCardPlusConfig;
+    // Neither entity has a numeric state; growthMap not involved (energy_date_selection: false)
+    // getEntityState returns null → getEntityStateWh returns 0
+    const hass = makeHass({
+      "sensor.grid_energy": "unavailable",
+      "sensor.solar_energy": "unavailable",
+    });
+    const card = makeCard(config, hass);
+    const data = card._computeRenderData();
+
+    expect(Number.isNaN(data.grid.state.fromGrid)).toBe(false);
+    expect(Number.isNaN(data.grid.state.toGrid)).toBe(false);
+    expect(Number.isNaN(data.grid.state.toBattery)).toBe(false);
+    expect(Number.isNaN(data.grid.state.toHome)).toBe(false);
+    expect(Number.isNaN(data.solar.state.total)).toBe(false);
+    expect(Number.isNaN(data.solar.state.toHome)).toBe(false);
   });
 });

--- a/packages/flixlix-cards/energy-flow-card-plus/__tests__/ui-editor.test.ts
+++ b/packages/flixlix-cards/energy-flow-card-plus/__tests__/ui-editor.test.ts
@@ -97,4 +97,22 @@ describe("energy flow ui editor", () => {
     const config = configChanged.mock.calls[0]?.[0]?.detail?.config;
     expect(config.entities.grid).toEqual({ entity: "sensor.new_grid" });
   });
+
+  test("_editDetailElement sets _currentConfigPage and _goBack resets it", () => {
+    const editor = new PowerFlowCardPlusEditor();
+
+    (editor as any)._editDetailElement("grid");
+    expect((editor as any)._currentConfigPage).toBe("grid");
+
+    (editor as any)._goBack();
+    expect((editor as any)._currentConfigPage).toBeNull();
+  });
+
+  test("setConfig rejects invalid config", async () => {
+    const editor = new PowerFlowCardPlusEditor();
+
+    await expect(
+      editor.setConfig({ type: "custom:energy-flow-card-plus" } as any)
+    ).rejects.toThrow();
+  });
 });

--- a/packages/flixlix-cards/energy-flow-card-plus/src/ui-editor/ui-editor.ts
+++ b/packages/flixlix-cards/energy-flow-card-plus/src/ui-editor/ui-editor.ts
@@ -1,7 +1,6 @@
 import localize from "@flixlix-cards/shared/i18n";
 import {
   type ConfigPage,
-  type LovelaceRowConfig,
   type PowerFlowCardPlusConfig,
 } from "@flixlix-cards/shared/types";
 import "@flixlix-cards/shared/ui-editor/components/individual-devices-editor";
@@ -12,12 +11,11 @@ import { nonFossilSchema } from "@flixlix-cards/shared/ui-editor/schema/fossil-f
 import { gridSchema } from "@flixlix-cards/shared/ui-editor/schema/grid";
 import { homeSchema } from "@flixlix-cards/shared/ui-editor/schema/home";
 import { solarSchema } from "@flixlix-cards/shared/ui-editor/schema/solar";
-import { loadHaForm } from "@flixlix-cards/shared/ui-editor/utils/load-ha-form";
-import { defaultValues } from "@flixlix-cards/shared/utils/get-default-config";
-import { fireEvent, type HomeAssistant, type LovelaceCardEditor } from "custom-card-helpers";
-import { LitElement, css, html, nothing } from "lit";
-import { customElement, property, state } from "lit/decorators.js";
-import { assert } from "superstruct";
+import { BaseCardEditor } from "@flixlix-cards/shared/ui-editor/base-editor";
+import { fireEvent } from "custom-card-helpers";
+import { html, nothing, type TemplateResult } from "lit";
+import { customElement } from "lit/decorators.js";
+import { type Struct } from "superstruct";
 import { advancedOptionsSchema, cardConfigStruct, generalConfigSchema } from "./schema/_schema-all";
 
 const CONFIG_PAGES: {
@@ -62,28 +60,21 @@ const CONFIG_PAGES: {
 ];
 
 @customElement("energy-flow-card-plus-editor")
-export class PowerFlowCardPlusEditor extends LitElement implements LovelaceCardEditor {
-  @property({ attribute: false }) public hass!: HomeAssistant;
-  @state() private _config?: PowerFlowCardPlusConfig;
-  @state() private _configEntities?: LovelaceRowConfig[] = [];
-  @state() private _currentConfigPage: ConfigPage = null;
-
-  public async setConfig(config: PowerFlowCardPlusConfig): Promise<void> {
-    assert(config, cardConfigStruct);
-    this._config = config;
+export class PowerFlowCardPlusEditor extends BaseCardEditor<PowerFlowCardPlusConfig> {
+  protected get configStruct(): Struct<PowerFlowCardPlusConfig, any> {
+    return cardConfigStruct as unknown as Struct<PowerFlowCardPlusConfig, any>;
   }
 
-  connectedCallback(): void {
-    super.connectedCallback();
-    loadHaForm();
+  protected get configPages() {
+    return CONFIG_PAGES;
   }
 
-  private _editDetailElement(pageClicked: ConfigPage): void {
-    this._currentConfigPage = pageClicked;
+  protected get generalSchema() {
+    return generalConfigSchema;
   }
 
-  private _goBack(): void {
-    this._currentConfigPage = null;
+  protected advancedSchema(localizeFn: typeof localize, displayZeroLinesMode: string) {
+    return advancedOptionsSchema(localizeFn, displayZeroLinesMode);
   }
 
   private _hasLegacyFields(): boolean {
@@ -135,7 +126,7 @@ export class PowerFlowCardPlusEditor extends LitElement implements LovelaceCardE
     fireEvent(this, "config-changed", { config });
   }
 
-  private _renderLegacyFieldsAlert() {
+  private _renderLegacyFieldsAlert(): TemplateResult | typeof nothing {
     if (!this._hasLegacyFields()) return nothing;
     return html`
       <ha-alert class="legacy-fields-alert" alert-type="warning">
@@ -199,7 +190,7 @@ export class PowerFlowCardPlusEditor extends LitElement implements LovelaceCardE
     fireEvent(this, "config-changed", { config });
   }
 
-  private _renderLegacyIndividualFieldsAlert() {
+  private _renderLegacyIndividualFieldsAlert(): TemplateResult | typeof nothing {
     if (!this._hasLegacyIndividualFields()) return nothing;
     return html`
       <ha-alert class="legacy-fields-alert" alert-type="warning">
@@ -216,182 +207,11 @@ export class PowerFlowCardPlusEditor extends LitElement implements LovelaceCardE
     `;
   }
 
-  protected render() {
-    if (!this.hass || !this._config) {
-      return nothing;
-    }
-
-    const data = {
-      ...this._config,
-      display_zero_lines: {
-        mode: this._config.display_zero_lines?.mode ?? defaultValues.displayZeroLines.mode,
-        transparency:
-          this._config.display_zero_lines?.transparency ??
-          defaultValues.displayZeroLines.transparency,
-        grey_color:
-          this._config.display_zero_lines?.grey_color ?? defaultValues.displayZeroLines.grey_color,
-      },
-    };
-
-    if (this._currentConfigPage !== null) {
-      if (this._currentConfigPage === "individual") {
-        return html`
-          ${this._renderLegacyFieldsAlert()} ${this._renderLegacyIndividualFieldsAlert()}
-          <subpage-header @go-back=${this._goBack} page=${this._currentConfigPage}>
-          </subpage-header>
-          <individual-devices-editor
-            .hass=${this.hass}
-            .config=${this._config}
-            @config-changed=${this._valueChanged}
-          ></individual-devices-editor>
-        `;
-      }
-
-      const currentPage = this._currentConfigPage;
-      const schema =
-        currentPage === "advanced"
-          ? advancedOptionsSchema(
-              localize,
-              this._config.display_zero_lines?.mode ?? defaultValues.displayZeroLines.mode
-            )
-          : CONFIG_PAGES.find((page) => page.page === currentPage)?.schema;
-      const dataForForm = currentPage === "advanced" ? data : data.entities[currentPage];
-      return html`
-        ${this._renderLegacyFieldsAlert()} ${this._renderLegacyIndividualFieldsAlert()}
-        <subpage-header @go-back=${this._goBack} page=${this._currentConfigPage}> </subpage-header>
-        <ha-form
-          .hass=${this.hass}
-          .data=${dataForForm}
-          .schema=${schema}
-          .computeLabel=${this._computeLabelCallback}
-          @value-changed=${this._valueChanged}
-        ></ha-form>
-      `;
-    }
-
-    const renderLinkSubpage = (
-      page: ConfigPage,
-      fallbackIcon: string | undefined = "mdi:dots-horizontal-circle-outline"
-    ) => {
-      if (page === null) return nothing;
-      const getIconToUse = () => {
-        if (page === "individual" || page === "advanced") return fallbackIcon;
-        const entityConfig = this?._config?.entities[page] as { icon?: string } | undefined;
-        return entityConfig?.icon || fallbackIcon;
-      };
-      const icon = getIconToUse();
-      return html`
-        <link-subpage
-          path=${page}
-          header="${localize(`editor.${page}`)}"
-          @open-sub-element-editor=${() => this._editDetailElement(page)}
-          icon=${icon}
-        >
-        </link-subpage>
-      `;
-    };
-
-    const renderLinkSubPages = () => {
-      return CONFIG_PAGES.map((page) => renderLinkSubpage(page.page, page.icon));
-    };
-    return html`
-      <div class="card-config">
-        ${this._renderLegacyFieldsAlert()} ${this._renderLegacyIndividualFieldsAlert()}
-        <ha-form
-          .hass=${this.hass}
-          .data=${data}
-          .schema=${generalConfigSchema}
-          .computeLabel=${this._computeLabelCallback}
-          @value-changed=${this._valueChanged}
-        ></ha-form>
-        ${renderLinkSubPages()}
-      </div>
-    `;
-  }
-
-  private _valueChanged(ev: any): void {
-    let config = ev.detail.value || "";
-
-    if (!this._config || !this.hass) {
-      return;
-    }
-
-    if (
-      this._currentConfigPage !== null &&
-      this._currentConfigPage !== "advanced" &&
-      this._currentConfigPage !== "individual"
-    ) {
-      config = {
-        ...this._config,
-        entities: {
-          ...this._config.entities,
-          [this._currentConfigPage]: config,
-        },
-      };
-    }
-
-    fireEvent(this, "config-changed", { config });
-  }
-
-  private _computeLabelCallback = (schema: any) =>
-    this.hass!.localize(`ui.panel.lovelace.editor.card.generic.${schema?.name}`) ||
-    localize(`editor.${schema?.name}`) ||
-    schema?.label;
-
-  static get styles() {
-    return css`
-      ha-form {
-        width: 100%;
-      }
-
-      ha-icon-button {
-        align-self: center;
-      }
-
-      .entities-section * {
-        background-color: #f00;
-      }
-
-      .card-config {
-        display: flex;
-        flex-direction: column;
-        gap: 1.5rem;
-        margin-bottom: 10px;
-      }
-
-      .legacy-fields-alert {
-        margin-bottom: 8px;
-      }
-
-      .legacy-fields-alert-button {
-        border: none;
-        background: var(--warning-color);
-        border-radius: 99px;
-        color: var(--card-background-color);
-        cursor: pointer;
-        font: inherit;
-        padding: 4px 8px;
-      }
-
-      .config-header {
-        display: flex;
-        flex-direction: row;
-        justify-content: space-between;
-        align-items: center;
-        width: 100%;
-      }
-
-      .config-header.sub-header {
-        margin-top: 24px;
-      }
-
-      ha-icon {
-        padding-bottom: 2px;
-        position: relative;
-        top: -4px;
-        right: 1px;
-      }
-    `;
+  protected _renderLegacyAlerts(): TemplateResult | typeof nothing {
+    const legacy = this._renderLegacyFieldsAlert();
+    const individual = this._renderLegacyIndividualFieldsAlert();
+    if (legacy === nothing && individual === nothing) return nothing;
+    return html`${legacy}${individual}`;
   }
 }
 

--- a/packages/flixlix-cards/energy-flow-card-plus/src/ui-editor/ui-editor.ts
+++ b/packages/flixlix-cards/energy-flow-card-plus/src/ui-editor/ui-editor.ts
@@ -1,8 +1,5 @@
-import localize from "@flixlix-cards/shared/i18n";
-import {
-  type ConfigPage,
-  type PowerFlowCardPlusConfig,
-} from "@flixlix-cards/shared/types";
+import { type ConfigPage, type PowerFlowCardPlusConfig } from "@flixlix-cards/shared/types";
+import { BaseCardEditor } from "@flixlix-cards/shared/ui-editor/base-editor";
 import "@flixlix-cards/shared/ui-editor/components/individual-devices-editor";
 import "@flixlix-cards/shared/ui-editor/components/link-subpage";
 import "@flixlix-cards/shared/ui-editor/components/subpage-header";
@@ -11,7 +8,6 @@ import { nonFossilSchema } from "@flixlix-cards/shared/ui-editor/schema/fossil-f
 import { gridSchema } from "@flixlix-cards/shared/ui-editor/schema/grid";
 import { homeSchema } from "@flixlix-cards/shared/ui-editor/schema/home";
 import { solarSchema } from "@flixlix-cards/shared/ui-editor/schema/solar";
-import { BaseCardEditor } from "@flixlix-cards/shared/ui-editor/base-editor";
 import { fireEvent } from "custom-card-helpers";
 import { html, nothing, type TemplateResult } from "lit";
 import { customElement } from "lit/decorators.js";
@@ -73,7 +69,7 @@ export class PowerFlowCardPlusEditor extends BaseCardEditor<PowerFlowCardPlusCon
     return generalConfigSchema;
   }
 
-  protected advancedSchema(localizeFn: typeof localize, displayZeroLinesMode: string) {
+  protected advancedSchema(localizeFn: (key: string) => string, displayZeroLinesMode: string) {
     return advancedOptionsSchema(localizeFn, displayZeroLinesMode);
   }
 

--- a/packages/flixlix-cards/power-flow-card-plus/__tests__/render.test.ts
+++ b/packages/flixlix-cards/power-flow-card-plus/__tests__/render.test.ts
@@ -5,6 +5,76 @@ import { describe, expect, test } from "vitest";
 import { type PowerFlowCardPlusConfig } from "@flixlix-cards/shared/types";
 import { PowerFlowCardPlus } from "../src/power-flow-card-plus";
 
+// jsdom does not provide ResizeObserver; stub it so the card's `updated` hook doesn't throw
+(globalThis as any).ResizeObserver = class {
+  observe() {}
+  disconnect() {}
+  unobserve() {}
+};
+
+type HassState = { state: string; attributes: Record<string, unknown> };
+
+function makeHass(states: Record<string, string> = {}) {
+  const hassStates: Record<string, HassState> = {};
+  for (const [entityId, state] of Object.entries(states)) {
+    hassStates[entityId] = {
+      state,
+      attributes: { friendly_name: entityId, unit_of_measurement: "W" },
+    };
+  }
+  return {
+    localize: (key: string) => key,
+    locale: { language: "en", number_format: "comma_decimal" },
+    states: hassStates,
+    config: {},
+    user: { name: "test" },
+    connection: {},
+  } as any;
+}
+
+function makeCard(config: PowerFlowCardPlusConfig, hass: ReturnType<typeof makeHass>) {
+  const card = new PowerFlowCardPlus();
+  card.setConfig(config);
+  card.hass = hass;
+  card.connectedCallback();
+  return card as unknown as {
+    render: () => unknown;
+    _computeRenderData: () => ReturnType<typeof computeRenderDataShape>;
+  };
+}
+
+// Used only as a type reference — actual return shape is inferred from _computeRenderData
+declare function computeRenderDataShape(): {
+  grid: {
+    has: boolean;
+    state: {
+      fromGrid: number | null;
+      toGrid: number | null;
+      toBattery: number | null;
+      toHome: number | null;
+    };
+  };
+  solar: {
+    has: boolean;
+    state: {
+      total: number | null;
+      toHome: number | null;
+      toGrid: number | null;
+      toBattery: number | null;
+    };
+  };
+  battery: {
+    has: boolean | string;
+    state: {
+      fromBattery: number | null;
+      toBattery: number | null;
+      toGrid: number | null;
+      toHome: number | null;
+    };
+  };
+  individualObjs: Array<{ has: boolean; state: number | null }>;
+};
+
 describe("render", () => {
   test("renders correctly", () => {
     const config = {
@@ -20,5 +90,108 @@ describe("render", () => {
     card.connectedCallback();
     const rendered = (card as unknown as { render: () => unknown }).render();
     expect(rendered).toBeTruthy();
+  });
+});
+
+describe("_computeRenderData", () => {
+  test("case 1: grid-only consumption — fromGrid is the entity value and toHome follows", () => {
+    const config = {
+      type: "custom:power-flow-card-plus",
+      entities: {
+        grid: { entity: "sensor.grid" },
+      },
+    } as PowerFlowCardPlusConfig;
+    const hass = makeHass({ "sensor.grid": "500" });
+    const card = makeCard(config, hass);
+    const data = card._computeRenderData();
+
+    expect(data.grid.state.fromGrid).toBe(500);
+    // toHome = max(fromGrid - toBattery, 0) = max(500 - 0, 0) = 500
+    expect(data.grid.state.toHome).toBe(500);
+    // No solar entity configured
+    expect(data.solar.has).toBe(false);
+    // No battery entity configured → battery.has is falsy
+    expect(data.battery.has).toBeFalsy();
+  });
+
+  test("case 2: solar covers home and grid is zero — dependency rule zeroes grid toHome", () => {
+    const config = {
+      type: "custom:power-flow-card-plus",
+      entities: {
+        grid: { entity: "sensor.grid" },
+        solar: { entity: "sensor.solar" },
+      },
+    } as PowerFlowCardPlusConfig;
+    // grid produces nothing (0W), solar produces 1000W
+    const hass = makeHass({ "sensor.grid": "0", "sensor.solar": "1000" });
+    const card = makeCard(config, hass);
+    const data = card._computeRenderData();
+
+    expect(data.solar.state.total).toBe(1000);
+    // fromGrid === 0 → the dependency rule at lines 791-794 forces toHome and toBattery to 0
+    expect(data.grid.state.fromGrid).toBe(0);
+    expect(data.grid.state.toHome).toBe(0);
+    expect(data.grid.state.toBattery).toBe(0);
+    // Solar covers all home consumption
+    expect(data.solar.state.toHome).toBe(1000);
+  });
+
+  test("case 3: tolerance zeroing — grid below tolerance is treated as 0", () => {
+    const config = {
+      type: "custom:power-flow-card-plus",
+      entities: {
+        grid: { entity: "sensor.grid", display_zero_tolerance: 5 } as any,
+      },
+    } as PowerFlowCardPlusConfig;
+    // 3W is below the 5W tolerance
+    const hass = makeHass({ "sensor.grid": "3" });
+    const card = makeCard(config, hass);
+    const data = card._computeRenderData();
+
+    expect(data.grid.state.fromGrid).toBe(0);
+    // Dependency rule: fromGrid === 0 → toHome and toBattery also zeroed
+    expect(data.grid.state.toHome).toBe(0);
+    expect(data.grid.state.toBattery).toBe(0);
+  });
+
+  test("case 4: negative individual entity stays visible (Plan 001 regression guard)", () => {
+    const config = {
+      type: "custom:power-flow-card-plus",
+      entities: {
+        grid: { entity: "sensor.grid" },
+        individual: [{ entity: "sensor.device" }],
+      },
+    } as PowerFlowCardPlusConfig;
+    // Individual state is negative; getIndividualState applies Math.abs so state === 50
+    const hass = makeHass({ "sensor.grid": "100", "sensor.device": "-50" });
+    const card = makeCard(config, hass);
+    const data = card._computeRenderData();
+
+    expect(data.individualObjs).toHaveLength(1);
+    const individual = data.individualObjs[0];
+    // has === true: the device is visible even with a negative raw state
+    expect(individual.has).toBe(true);
+    // getIndividualState returns Math.abs of the raw value
+    expect(individual.state).toBe(50);
+  });
+
+  test("case 5: unavailable entity — no NaN in grid state fields", () => {
+    const config = {
+      type: "custom:power-flow-card-plus",
+      entities: {
+        grid: { entity: "sensor.grid" },
+        solar: { entity: "sensor.solar" },
+      },
+    } as PowerFlowCardPlusConfig;
+    // "unavailable" is not a number; getEntityState returns null → getEntityStateWatts returns 0
+    const hass = makeHass({ "sensor.grid": "unavailable", "sensor.solar": "unavailable" });
+    const card = makeCard(config, hass);
+    const data = card._computeRenderData();
+
+    expect(Number.isNaN(data.grid.state.fromGrid)).toBe(false);
+    expect(Number.isNaN(data.grid.state.toGrid)).toBe(false);
+    expect(Number.isNaN(data.grid.state.toBattery)).toBe(false);
+    expect(Number.isNaN(data.grid.state.toHome)).toBe(false);
+    expect(Number.isNaN(data.solar.state.total)).toBe(false);
   });
 });

--- a/packages/flixlix-cards/power-flow-card-plus/__tests__/ui-editor.test.ts
+++ b/packages/flixlix-cards/power-flow-card-plus/__tests__/ui-editor.test.ts
@@ -94,4 +94,22 @@ describe("power flow ui editor", () => {
     const config = configChanged.mock.calls[0]?.[0]?.detail?.config;
     expect(config.entities.grid).toEqual({ entity: "sensor.new_grid" });
   });
+
+  test("_editDetailElement sets _currentConfigPage and _goBack resets it", () => {
+    const editor = new PowerFlowCardPlusEditor();
+
+    (editor as any)._editDetailElement("grid");
+    expect((editor as any)._currentConfigPage).toBe("grid");
+
+    (editor as any)._goBack();
+    expect((editor as any)._currentConfigPage).toBeNull();
+  });
+
+  test("setConfig rejects invalid config", async () => {
+    const editor = new PowerFlowCardPlusEditor();
+
+    await expect(
+      editor.setConfig({ type: "custom:power-flow-card-plus" } as any)
+    ).rejects.toThrow();
+  });
 });

--- a/packages/flixlix-cards/power-flow-card-plus/src/ui-editor/ui-editor.ts
+++ b/packages/flixlix-cards/power-flow-card-plus/src/ui-editor/ui-editor.ts
@@ -1,9 +1,5 @@
-import localize from "@flixlix-cards/shared/i18n";
-import {
-  type ConfigPage,
-  type PowerFlowCardPlusConfig,
-  type LovelaceRowConfig,
-} from "@flixlix-cards/shared/types";
+import { type ConfigPage, type PowerFlowCardPlusConfig } from "@flixlix-cards/shared/types";
+import { BaseCardEditor } from "@flixlix-cards/shared/ui-editor/base-editor";
 import "@flixlix-cards/shared/ui-editor/components/individual-devices-editor";
 import "@flixlix-cards/shared/ui-editor/components/link-subpage";
 import "@flixlix-cards/shared/ui-editor/components/subpage-header";
@@ -12,11 +8,10 @@ import { nonFossilSchema } from "@flixlix-cards/shared/ui-editor/schema/fossil-f
 import { gridSchema } from "@flixlix-cards/shared/ui-editor/schema/grid";
 import { homeSchema } from "@flixlix-cards/shared/ui-editor/schema/home";
 import { solarSchema } from "@flixlix-cards/shared/ui-editor/schema/solar";
-import { BaseCardEditor } from "@flixlix-cards/shared/ui-editor/base-editor";
 import { fireEvent } from "custom-card-helpers";
 import { html, nothing, type TemplateResult } from "lit";
 import { customElement } from "lit/decorators.js";
-import { type Struct, assert } from "superstruct";
+import { type Struct } from "superstruct";
 import { advancedOptionsSchema, cardConfigStruct, generalConfigSchema } from "./schema/_schema-all";
 
 const CONFIG_PAGES: {
@@ -74,7 +69,7 @@ export class PowerFlowCardPlusEditor extends BaseCardEditor<PowerFlowCardPlusCon
     return generalConfigSchema;
   }
 
-  protected advancedSchema(localizeFn: typeof localize, displayZeroLinesMode: string) {
+  protected advancedSchema(localizeFn: (key: string) => string, displayZeroLinesMode: string) {
     return advancedOptionsSchema(localizeFn, displayZeroLinesMode);
   }
 

--- a/packages/flixlix-cards/power-flow-card-plus/src/ui-editor/ui-editor.ts
+++ b/packages/flixlix-cards/power-flow-card-plus/src/ui-editor/ui-editor.ts
@@ -1,8 +1,8 @@
 import localize from "@flixlix-cards/shared/i18n";
 import {
   type ConfigPage,
-  type LovelaceRowConfig,
   type PowerFlowCardPlusConfig,
+  type LovelaceRowConfig,
 } from "@flixlix-cards/shared/types";
 import "@flixlix-cards/shared/ui-editor/components/individual-devices-editor";
 import "@flixlix-cards/shared/ui-editor/components/link-subpage";
@@ -12,12 +12,11 @@ import { nonFossilSchema } from "@flixlix-cards/shared/ui-editor/schema/fossil-f
 import { gridSchema } from "@flixlix-cards/shared/ui-editor/schema/grid";
 import { homeSchema } from "@flixlix-cards/shared/ui-editor/schema/home";
 import { solarSchema } from "@flixlix-cards/shared/ui-editor/schema/solar";
-import { loadHaForm } from "@flixlix-cards/shared/ui-editor/utils/load-ha-form";
-import { defaultValues } from "@flixlix-cards/shared/utils/get-default-config";
-import { fireEvent, type HomeAssistant, type LovelaceCardEditor } from "custom-card-helpers";
-import { LitElement, css, html, nothing } from "lit";
-import { customElement, property, state } from "lit/decorators.js";
-import { assert } from "superstruct";
+import { BaseCardEditor } from "@flixlix-cards/shared/ui-editor/base-editor";
+import { fireEvent } from "custom-card-helpers";
+import { html, nothing, type TemplateResult } from "lit";
+import { customElement } from "lit/decorators.js";
+import { type Struct, assert } from "superstruct";
 import { advancedOptionsSchema, cardConfigStruct, generalConfigSchema } from "./schema/_schema-all";
 
 const CONFIG_PAGES: {
@@ -62,28 +61,21 @@ const CONFIG_PAGES: {
 ];
 
 @customElement("power-flow-card-plus-editor")
-export class PowerFlowCardPlusEditor extends LitElement implements LovelaceCardEditor {
-  @property({ attribute: false }) public hass!: HomeAssistant;
-  @state() private _config?: PowerFlowCardPlusConfig;
-  @state() private _configEntities?: LovelaceRowConfig[] = [];
-  @state() private _currentConfigPage: ConfigPage = null;
-
-  public async setConfig(config: PowerFlowCardPlusConfig): Promise<void> {
-    assert(config, cardConfigStruct);
-    this._config = config;
+export class PowerFlowCardPlusEditor extends BaseCardEditor<PowerFlowCardPlusConfig> {
+  protected get configStruct(): Struct<PowerFlowCardPlusConfig, any> {
+    return cardConfigStruct as unknown as Struct<PowerFlowCardPlusConfig, any>;
   }
 
-  connectedCallback(): void {
-    super.connectedCallback();
-    loadHaForm();
+  protected get configPages() {
+    return CONFIG_PAGES;
   }
 
-  private _editDetailElement(pageClicked: ConfigPage): void {
-    this._currentConfigPage = pageClicked;
+  protected get generalSchema() {
+    return generalConfigSchema;
   }
 
-  private _goBack(): void {
-    this._currentConfigPage = null;
+  protected advancedSchema(localizeFn: typeof localize, displayZeroLinesMode: string) {
+    return advancedOptionsSchema(localizeFn, displayZeroLinesMode);
   }
 
   private _hasLegacyFields(): boolean {
@@ -117,7 +109,7 @@ export class PowerFlowCardPlusEditor extends LitElement implements LovelaceCardE
     fireEvent(this, "config-changed", { config });
   }
 
-  private _renderLegacyFieldsAlert() {
+  private _renderLegacyFieldsAlert(): TemplateResult | typeof nothing {
     if (!this._hasLegacyFields()) return nothing;
     return html`
       <ha-alert class="legacy-fields-alert" alert-type="warning">
@@ -180,7 +172,7 @@ export class PowerFlowCardPlusEditor extends LitElement implements LovelaceCardE
     fireEvent(this, "config-changed", { config });
   }
 
-  private _renderLegacyIndividualFieldsAlert() {
+  private _renderLegacyIndividualFieldsAlert(): TemplateResult | typeof nothing {
     if (!this._hasLegacyIndividualFields()) return nothing;
     return html`
       <ha-alert class="legacy-fields-alert" alert-type="warning">
@@ -197,181 +189,11 @@ export class PowerFlowCardPlusEditor extends LitElement implements LovelaceCardE
     `;
   }
 
-  protected render() {
-    if (!this.hass || !this._config) {
-      return nothing;
-    }
-    const data = {
-      ...this._config,
-      display_zero_lines: {
-        mode: this._config.display_zero_lines?.mode ?? defaultValues.displayZeroLines.mode,
-        transparency:
-          this._config.display_zero_lines?.transparency ??
-          defaultValues.displayZeroLines.transparency,
-        grey_color:
-          this._config.display_zero_lines?.grey_color ?? defaultValues.displayZeroLines.grey_color,
-      },
-    };
-
-    if (this._currentConfigPage !== null) {
-      if (this._currentConfigPage === "individual") {
-        return html`
-          ${this._renderLegacyFieldsAlert()}${this._renderLegacyIndividualFieldsAlert()}
-          <subpage-header @go-back=${this._goBack} page=${this._currentConfigPage}>
-          </subpage-header>
-          <individual-devices-editor
-            .hass=${this.hass}
-            .config=${this._config}
-            @config-changed=${this._valueChanged}
-          ></individual-devices-editor>
-        `;
-      }
-
-      const currentPage = this._currentConfigPage;
-      const schema =
-        currentPage === "advanced"
-          ? advancedOptionsSchema(
-              localize,
-              this._config.display_zero_lines?.mode ?? defaultValues.displayZeroLines.mode
-            )
-          : CONFIG_PAGES.find((page) => page.page === currentPage)?.schema;
-      const dataForForm = currentPage === "advanced" ? data : data.entities[currentPage];
-      return html`
-        ${this._renderLegacyFieldsAlert()}${this._renderLegacyIndividualFieldsAlert()}
-        <subpage-header @go-back=${this._goBack} page=${this._currentConfigPage}> </subpage-header>
-        <ha-form
-          .hass=${this.hass}
-          .data=${dataForForm}
-          .schema=${schema}
-          .computeLabel=${this._computeLabelCallback}
-          @value-changed=${this._valueChanged}
-        ></ha-form>
-      `;
-    }
-
-    const renderLinkSubpage = (
-      page: ConfigPage,
-      fallbackIcon: string | undefined = "mdi:dots-horizontal-circle-outline"
-    ) => {
-      if (page === null) return nothing;
-      const getIconToUse = () => {
-        if (page === "individual" || page === "advanced") return fallbackIcon;
-        const entityConfig = this?._config?.entities[page] as { icon?: string } | undefined;
-        return entityConfig?.icon || fallbackIcon;
-      };
-      const icon = getIconToUse();
-      return html`
-        <link-subpage
-          path=${page}
-          header="${localize(`editor.${page}`)}"
-          @open-sub-element-editor=${() => this._editDetailElement(page)}
-          icon=${icon}
-        >
-        </link-subpage>
-      `;
-    };
-
-    const renderLinkSubPages = () => {
-      return CONFIG_PAGES.map((page) => renderLinkSubpage(page.page, page.icon));
-    };
-    return html`
-      <div class="card-config">
-        ${this._renderLegacyFieldsAlert()}${this._renderLegacyIndividualFieldsAlert()}
-        <ha-form
-          .hass=${this.hass}
-          .data=${data}
-          .schema=${generalConfigSchema}
-          .computeLabel=${this._computeLabelCallback}
-          @value-changed=${this._valueChanged}
-        ></ha-form>
-        ${renderLinkSubPages()}
-      </div>
-    `;
-  }
-
-  private _valueChanged(ev: any): void {
-    let config = ev.detail.value || "";
-
-    if (!this._config || !this.hass) {
-      return;
-    }
-
-    if (
-      this._currentConfigPage !== null &&
-      this._currentConfigPage !== "advanced" &&
-      this._currentConfigPage !== "individual"
-    ) {
-      config = {
-        ...this._config,
-        entities: {
-          ...this._config.entities,
-          [this._currentConfigPage]: config,
-        },
-      };
-    }
-
-    fireEvent(this, "config-changed", { config });
-  }
-
-  private _computeLabelCallback = (schema: any) =>
-    this.hass!.localize(`ui.panel.lovelace.editor.card.generic.${schema?.name}`) ||
-    localize(`editor.${schema?.name}`) ||
-    schema?.label;
-
-  static get styles() {
-    return css`
-      ha-form {
-        width: 100%;
-      }
-
-      ha-icon-button {
-        align-self: center;
-      }
-
-      .entities-section * {
-        background-color: #f00;
-      }
-
-      .card-config {
-        display: flex;
-        flex-direction: column;
-        gap: 1.5rem;
-        margin-bottom: 10px;
-      }
-
-      .legacy-fields-alert {
-        margin-bottom: 8px;
-      }
-
-      .legacy-fields-alert-button {
-        border: none;
-        background: var(--warning-color);
-        border-radius: 99px;
-        color: var(--card-background-color);
-        cursor: pointer;
-        font: inherit;
-        padding: 4px 8px;
-      }
-
-      .config-header {
-        display: flex;
-        flex-direction: row;
-        justify-content: space-between;
-        align-items: center;
-        width: 100%;
-      }
-
-      .config-header.sub-header {
-        margin-top: 24px;
-      }
-
-      ha-icon {
-        padding-bottom: 2px;
-        position: relative;
-        top: -4px;
-        right: 1px;
-      }
-    `;
+  protected _renderLegacyAlerts(): TemplateResult | typeof nothing {
+    const legacy = this._renderLegacyFieldsAlert();
+    const individual = this._renderLegacyIndividualFieldsAlert();
+    if (legacy === nothing && individual === nothing) return nothing;
+    return html`${legacy}${individual}`;
   }
 }
 

--- a/packages/shared/__tests__/tolerance.test.ts
+++ b/packages/shared/__tests__/tolerance.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from "vitest";
+
+import { hasIndividualObject } from "../src/states/raw/individual/has-individual-object";
+import { adjustZeroTolerance, isAboveTolerance } from "../src/states/tolerance/base";
+
+describe("adjustZeroTolerance", () => {
+  test("null input returns 0", () => {
+    expect(adjustZeroTolerance(null, 5)).toBe(0);
+  });
+
+  test("zero input returns 0", () => {
+    expect(adjustZeroTolerance(0, 5)).toBe(0);
+  });
+
+  test("positive below tolerance returns 0", () => {
+    expect(adjustZeroTolerance(0.5, 5)).toBe(0);
+  });
+
+  test("positive at/above tolerance returns value", () => {
+    expect(adjustZeroTolerance(7, 5)).toBe(7);
+  });
+
+  test("no tolerance returns value unchanged", () => {
+    expect(adjustZeroTolerance(7, undefined)).toBe(7);
+  });
+
+  test("negative above tolerance (regression: should return -50, not 0)", () => {
+    expect(adjustZeroTolerance(-50, 5)).toBe(-50);
+  });
+
+  test("negative below tolerance returns 0", () => {
+    expect(adjustZeroTolerance(-0.5, 5)).toBe(0);
+  });
+});
+
+describe("isAboveTolerance", () => {
+  test("zero value returns false", () => {
+    expect(isAboveTolerance(0, 0)).toBe(false);
+  });
+
+  test("negative value above tolerance magnitude (regression: should return true)", () => {
+    expect(isAboveTolerance(-50, 0)).toBe(true);
+  });
+});
+
+describe("hasIndividualObject", () => {
+  test("negative state above tolerance is visible (user-visible bug regression)", () => {
+    expect(hasIndividualObject(false, -50, 0)).toBe(true);
+  });
+});

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -44,8 +44,6 @@
   "packageManager": "pnpm@10.33.0",
   "dependencies": {
     "@mdi/js": "catalog:packages",
-    "lit-element": "catalog:packages",
-    "lit-html": "catalog:packages",
     "memoize-one": "catalog:packages",
     "sortable": "^2.0.0",
     "sortablejs": "^1.15.7",

--- a/packages/shared/src/states/tolerance/base.ts
+++ b/packages/shared/src/states/tolerance/base.ts
@@ -1,5 +1,5 @@
 export const isAboveTolerance = (value: number | null, tolerance: number): boolean =>
-  !!value && value >= tolerance;
+  value !== null && value !== 0 && Math.abs(value) >= tolerance;
 
 export const adjustZeroTolerance = (
   value: number | null,

--- a/packages/shared/src/ui-editor/base-editor.ts
+++ b/packages/shared/src/ui-editor/base-editor.ts
@@ -1,8 +1,5 @@
 import localize from "@flixlix-cards/shared/i18n";
-import {
-  type ConfigPage,
-  type LovelaceRowConfig,
-} from "@flixlix-cards/shared/types";
+import { type ConfigPage, type LovelaceRowConfig } from "@flixlix-cards/shared/types";
 import { loadHaForm } from "@flixlix-cards/shared/ui-editor/utils/load-ha-form";
 import { defaultValues } from "@flixlix-cards/shared/utils/get-default-config";
 import {
@@ -13,7 +10,7 @@ import {
 } from "custom-card-helpers";
 import { LitElement, css, html, nothing, type TemplateResult } from "lit";
 import { property, state } from "lit/decorators.js";
-import { type Struct, assert } from "superstruct";
+import { assert, type Struct } from "superstruct";
 
 /**
  * Abstract base class for flow-card UI editors.
@@ -50,11 +47,11 @@ export abstract class BaseCardEditor<TConfig extends LovelaceCardConfig>
   protected abstract get generalSchema(): any;
 
   /**
-   * Schema for the "advanced" subpage.  Receives `localize` and the current
-   * `display_zero_lines.mode` value so card-specific options can be built.
+   * Schema for the "advanced" subpage.  Receives a localize function and the
+   * current `display_zero_lines.mode` value so card-specific options can be built.
    */
   protected abstract advancedSchema(
-    localizeFn: typeof localize,
+    localizeFn: (key: string) => string,
     displayZeroLinesMode: string
   ): any;
 
@@ -150,9 +147,7 @@ export abstract class BaseCardEditor<TConfig extends LovelaceCardConfig>
       if (page === null) return nothing;
       const getIconToUse = () => {
         if (page === "individual" || page === "advanced") return fallbackIcon;
-        const entityConfig = (this._config as any)?.entities[page] as
-          | { icon?: string }
-          | undefined;
+        const entityConfig = (this._config as any)?.entities[page] as { icon?: string } | undefined;
         return entityConfig?.icon || fallbackIcon;
       };
       const icon = getIconToUse();

--- a/packages/shared/src/ui-editor/base-editor.ts
+++ b/packages/shared/src/ui-editor/base-editor.ts
@@ -1,0 +1,277 @@
+import localize from "@flixlix-cards/shared/i18n";
+import {
+  type ConfigPage,
+  type LovelaceRowConfig,
+} from "@flixlix-cards/shared/types";
+import { loadHaForm } from "@flixlix-cards/shared/ui-editor/utils/load-ha-form";
+import { defaultValues } from "@flixlix-cards/shared/utils/get-default-config";
+import {
+  fireEvent,
+  type HomeAssistant,
+  type LovelaceCardConfig,
+  type LovelaceCardEditor,
+} from "custom-card-helpers";
+import { LitElement, css, html, nothing, type TemplateResult } from "lit";
+import { property, state } from "lit/decorators.js";
+import { type Struct, assert } from "superstruct";
+
+/**
+ * Abstract base class for flow-card UI editors.
+ *
+ * Subclasses must provide:
+ *  - `configStruct`   — superstruct Struct used to validate setConfig input
+ *  - `configPages`    — ordered list of CONFIG_PAGES entries
+ *  - `generalSchema`  — ha-form schema shown on the root (non-subpage) screen
+ *  - `advancedSchema` — ha-form schema for the "advanced" subpage
+ *  - `_renderLegacyAlerts()` — card-specific legacy-migration alert markup
+ *
+ * Do NOT add `@customElement` here — each subclass registers its own name.
+ */
+export abstract class BaseCardEditor<TConfig extends LovelaceCardConfig>
+  extends LitElement
+  implements LovelaceCardEditor
+{
+  @property({ attribute: false }) public hass!: HomeAssistant;
+  @state() protected _config?: TConfig;
+  @state() protected _configEntities?: LovelaceRowConfig[] = [];
+  @state() protected _currentConfigPage: ConfigPage = null;
+
+  // ── Abstract surface ─────────────────────────────────────────────────────
+
+  protected abstract get configStruct(): Struct<TConfig, any>;
+
+  protected abstract get configPages(): {
+    page: ConfigPage;
+    icon?: string;
+    schema?: any;
+  }[];
+
+  /** Schema for the root ha-form (general config). */
+  protected abstract get generalSchema(): any;
+
+  /**
+   * Schema for the "advanced" subpage.  Receives `localize` and the current
+   * `display_zero_lines.mode` value so card-specific options can be built.
+   */
+  protected abstract advancedSchema(
+    localizeFn: typeof localize,
+    displayZeroLinesMode: string
+  ): any;
+
+  /**
+   * Override to return legacy-migration alert markup.
+   * Return `nothing` if there are no applicable legacy fields.
+   */
+  protected _renderLegacyAlerts(): TemplateResult | typeof nothing {
+    return nothing;
+  }
+
+  // ── LovelaceCardEditor ────────────────────────────────────────────────────
+
+  public async setConfig(config: TConfig): Promise<void> {
+    assert(config, this.configStruct);
+    this._config = config;
+  }
+
+  connectedCallback(): void {
+    super.connectedCallback();
+    loadHaForm();
+  }
+
+  // ── Navigation ────────────────────────────────────────────────────────────
+
+  protected _editDetailElement(pageClicked: ConfigPage): void {
+    this._currentConfigPage = pageClicked;
+  }
+
+  protected _goBack(): void {
+    this._currentConfigPage = null;
+  }
+
+  // ── Render ────────────────────────────────────────────────────────────────
+
+  protected render() {
+    if (!this.hass || !this._config) {
+      return nothing;
+    }
+
+    const data = {
+      ...this._config,
+      display_zero_lines: {
+        mode: this._config.display_zero_lines?.mode ?? defaultValues.displayZeroLines.mode,
+        transparency:
+          this._config.display_zero_lines?.transparency ??
+          defaultValues.displayZeroLines.transparency,
+        grey_color:
+          this._config.display_zero_lines?.grey_color ?? defaultValues.displayZeroLines.grey_color,
+      },
+    };
+
+    if (this._currentConfigPage !== null) {
+      if (this._currentConfigPage === "individual") {
+        return html`
+          ${this._renderLegacyAlerts()}
+          <subpage-header @go-back=${this._goBack} page=${this._currentConfigPage}>
+          </subpage-header>
+          <individual-devices-editor
+            .hass=${this.hass}
+            .config=${this._config}
+            @config-changed=${this._valueChanged}
+          ></individual-devices-editor>
+        `;
+      }
+
+      const currentPage = this._currentConfigPage;
+      const schema =
+        currentPage === "advanced"
+          ? this.advancedSchema(
+              localize,
+              this._config.display_zero_lines?.mode ?? defaultValues.displayZeroLines.mode
+            )
+          : this.configPages.find((page) => page.page === currentPage)?.schema;
+      const dataForForm = currentPage === "advanced" ? data : (data as any).entities[currentPage];
+      return html`
+        ${this._renderLegacyAlerts()}
+        <subpage-header @go-back=${this._goBack} page=${this._currentConfigPage}> </subpage-header>
+        <ha-form
+          .hass=${this.hass}
+          .data=${dataForForm}
+          .schema=${schema}
+          .computeLabel=${this._computeLabelCallback}
+          @value-changed=${this._valueChanged}
+        ></ha-form>
+      `;
+    }
+
+    const renderLinkSubpage = (
+      page: ConfigPage,
+      fallbackIcon: string | undefined = "mdi:dots-horizontal-circle-outline"
+    ) => {
+      if (page === null) return nothing;
+      const getIconToUse = () => {
+        if (page === "individual" || page === "advanced") return fallbackIcon;
+        const entityConfig = (this._config as any)?.entities[page] as
+          | { icon?: string }
+          | undefined;
+        return entityConfig?.icon || fallbackIcon;
+      };
+      const icon = getIconToUse();
+      return html`
+        <link-subpage
+          path=${page}
+          header="${localize(`editor.${page}`)}"
+          @open-sub-element-editor=${() => this._editDetailElement(page)}
+          icon=${icon}
+        >
+        </link-subpage>
+      `;
+    };
+
+    const renderLinkSubPages = () => {
+      return this.configPages.map((page) => renderLinkSubpage(page.page, page.icon));
+    };
+
+    return html`
+      <div class="card-config">
+        ${this._renderLegacyAlerts()}
+        <ha-form
+          .hass=${this.hass}
+          .data=${data}
+          .schema=${this.generalSchema}
+          .computeLabel=${this._computeLabelCallback}
+          @value-changed=${this._valueChanged}
+        ></ha-form>
+        ${renderLinkSubPages()}
+      </div>
+    `;
+  }
+
+  // ── Event handling ────────────────────────────────────────────────────────
+
+  protected _valueChanged(ev: any): void {
+    let config = ev.detail.value || "";
+
+    if (!this._config || !this.hass) {
+      return;
+    }
+
+    if (
+      this._currentConfigPage !== null &&
+      this._currentConfigPage !== "advanced" &&
+      this._currentConfigPage !== "individual"
+    ) {
+      config = {
+        ...this._config,
+        entities: {
+          ...(this._config as any).entities,
+          [this._currentConfigPage]: config,
+        },
+      };
+    }
+
+    fireEvent(this, "config-changed", { config });
+  }
+
+  protected _computeLabelCallback = (schema: any) =>
+    this.hass!.localize(`ui.panel.lovelace.editor.card.generic.${schema?.name}`) ||
+    localize(`editor.${schema?.name}`) ||
+    schema?.label;
+
+  // ── Styles ────────────────────────────────────────────────────────────────
+
+  static get styles() {
+    return css`
+      ha-form {
+        width: 100%;
+      }
+
+      ha-icon-button {
+        align-self: center;
+      }
+
+      .entities-section * {
+        background-color: #f00;
+      }
+
+      .card-config {
+        display: flex;
+        flex-direction: column;
+        gap: 1.5rem;
+        margin-bottom: 10px;
+      }
+
+      .legacy-fields-alert {
+        margin-bottom: 8px;
+      }
+
+      .legacy-fields-alert-button {
+        border: none;
+        background: var(--warning-color);
+        border-radius: 99px;
+        color: var(--card-background-color);
+        cursor: pointer;
+        font: inherit;
+        padding: 4px 8px;
+      }
+
+      .config-header {
+        display: flex;
+        flex-direction: row;
+        justify-content: space-between;
+        align-items: center;
+        width: 100%;
+      }
+
+      .config-header.sub-header {
+        margin-top: 24px;
+      }
+
+      ha-icon {
+        padding-bottom: 2px;
+        position: relative;
+        top: -4px;
+        right: 1px;
+      }
+    `;
+  }
+}

--- a/packages/shared/src/ui-editor/components/individual-devices-editor.ts
+++ b/packages/shared/src/ui-editor/components/individual-devices-editor.ts
@@ -8,7 +8,7 @@ import {
 } from "@flixlix-cards/shared/types";
 import { fireEvent, type HASSDomEvent, type HomeAssistant } from "custom-card-helpers";
 import { css, type CSSResultGroup, html, LitElement, type TemplateResult } from "lit";
-import { property, state } from "lit-element";
+import { property, state } from "lit/decorators.js";
 import { individualDevicesSchema } from "../schema/_schema-all";
 import "./individual-row-editor";
 

--- a/packages/shared/src/ui-editor/components/link-subpage.ts
+++ b/packages/shared/src/ui-editor/components/link-subpage.ts
@@ -1,7 +1,7 @@
 import { mdiChevronRight } from "@mdi/js";
 import { fireEvent } from "custom-card-helpers";
 import { css, type CSSResultGroup, html, LitElement, type TemplateResult } from "lit";
-import { property, query } from "lit-element";
+import { property, query } from "lit/decorators.js";
 
 export class LinkSubpage extends LitElement {
   @property({ type: String }) path!: string;

--- a/packages/shared/src/ui-editor/components/subpage-header.ts
+++ b/packages/shared/src/ui-editor/components/subpage-header.ts
@@ -3,7 +3,7 @@ import { type ConfigPage, type PowerFlowCardPlusConfig } from "@flixlix-cards/sh
 import { mdiArrowLeft } from "@mdi/js";
 import { fireEvent, type HomeAssistant } from "custom-card-helpers";
 import { css, type CSSResultGroup, html, LitElement, type TemplateResult } from "lit";
-import { property } from "lit-element";
+import { property } from "lit/decorators.js";
 
 declare global {
   interface HASSDomEvents {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -846,12 +846,6 @@ importers:
       lit:
         specifier: catalog:packages
         version: 3.3.2
-      lit-element:
-        specifier: catalog:packages
-        version: 2.5.1
-      lit-html:
-        specifier: catalog:packages
-        version: 2.8.0
       memoize-one:
         specifier: catalog:packages
         version: 6.0.0
@@ -12067,7 +12061,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
-      vitest: 4.1.5(@types/node@25.6.0)(@vitest/ui@4.1.5)(happy-dom@20.9.0)(jsdom@28.1.0(@noble/hashes@1.8.0))(msw@2.14.2(@types/node@25.6.0)(typescript@6.0.2))(vite@7.3.2(@types/node@25.6.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.2))
+      vitest: 4.1.5(@types/node@22.19.17)(@vitest/ui@4.1.5)(happy-dom@20.9.0)(jsdom@28.1.0(@noble/hashes@1.8.0))(msw@2.14.2(@types/node@22.19.17)(typescript@5.9.3))(vite@7.3.2(@types/node@22.19.17)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.2))
 
   '@vitest/utils@3.2.4':
     dependencies:


### PR DESCRIPTION
Plan 007. Extracts the duplicated flow-card editor machinery into `BaseCardEditor` — **−367 lines** across the two editors.

**Reviewed (re-ran in worktree):** 12+12 editor tests, typecheck/build pass, custom-element names intact, no assertions weakened.

> **Depends on #003 + #004** — this branch includes their commits (base `main`); merge 003 and 004 first. Note: energy editor class still named `PowerFlowCardPlusEditor` (pre-existing; future rename).

🤖 Generated with [Claude Code](https://claude.com/claude-code)