### PR TITLE
docs: :memo: sync card lists and dev ports

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yaml
@@ -28,7 +28,8 @@ body:
       options:
         - Power Flow Card Plus
         - Energy Flow Card Plus
-        - Energy Period Selector Plus
+        - Energy Breakdown Card
+        - Sortable List Card
     validations:
       required: true
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/feature-request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yaml
@@ -23,7 +23,8 @@ body:
       options:
         - Power Flow Card Plus
         - Energy Flow Card Plus
-        - Energy Period Selector Plus
+        - Energy Breakdown Card
+        - Sortable List Card
     validations:
       required: true
   - type: textarea

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,6 +18,7 @@ Each card is located in its own folder inside [`packages/flixlix-cards`](package
 - `power-flow-card-plus`
 - `energy-flow-card-plus`
 - `energy-breakdown-card`
+- `sortable-list-card`
 
 Each package contains its source code, changelogs, and relevant scripts.
 
@@ -51,17 +52,14 @@ Each package contains its source code, changelogs, and relevant scripts.
    ```
 
 5. **Add the built card to Home Assistant’s dashboard resources:**  
-   (Change the filename to match the card you’re developing.)
+   Each card’s dev server runs on its own port. Use the URL for the card you’re developing:
 
-   ```text
-   http://<your-ip>:5001/<card-filename>.js
-   ```
-
-   Example for Power Flow Card Plus:
-
-   ```text
-   http://<your-ip>:5001/power-flow-card-plus.js
-   ```
+   | Card | Dev server URL |
+   |------|----------------|
+   | Power Flow Card Plus | `http://<your-ip>:5001/power-flow-card-plus.js` |
+   | Energy Flow Card Plus | `http://<your-ip>:5003/energy-flow-card-plus.js` |
+   | Energy Breakdown Card | `http://<your-ip>:5004/energy-breakdown-card.js` |
+   | Sortable List Card | `http://<your-ip>:5005/sortable-list-card.js` |
 
 6. **Open Home Assistant:**
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This is a monorepo for all my Home Assistant cards, including their source code,
 - **Power Flow Card Plus** — [docs](https://cards.flixlix.com/power-flow-card-plus) · [README](packages/flixlix-cards/power-flow-card-plus/README.md)
 - **Energy Flow Card Plus** — [docs](https://cards.flixlix.com/energy-flow-card-plus) · [README](packages/flixlix-cards/energy-flow-card-plus/README.md)
 - **Energy Breakdown Card** — [docs](https://cards.flixlix.com/energy-breakdown-card) · [README](packages/flixlix-cards/energy-breakdown-card/README.md)
+- **Sortable List Card** — [docs](https://cards.flixlix.com/sortable-list-card) · [README](packages/flixlix-cards/sortable-list-card/README.md)
 
 ![demo_power_flow_card_plus](https://user-images.githubusercontent.com/61006057/227771568-78497ecc-e863-46f2-b29e-e15c7c20a154.gif)
 ![demo_energy_flow_card_plus](https://github.com/flixlix/energy-flow-card-plus/assets/61006057/d3650e8a-1c82-4993-9951-18c04fbdf4d6)


### PR DESCRIPTION
Plan 010. Adds Sortable List Card to README, fixes both issue-template dropdowns (removes a card that lives in another repo), and replaces the single-port note with a per-card port table.

**Reviewed:** YAML valid, links resolve, scope clean.
Follow-up (out of scope): `.github/workflows/issue-labeler.yaml` still maps the removed card and not the two new ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)