### PR TITLE
fix: :bug: cap individual devices at four template topics

### DIFF
--- a/.changeset/fix-individual-template-topics.md
+++ b/.changeset/fix-individual-template-topics.md
@@ -1,0 +1,13 @@
+---
+"power-flow-card-plus": patch
+"energy-flow-card-plus": patch
+---
+
+fix: cap individual devices at four template topics
+
+A 5th+ entry in `entities.individual` would produce the topic `"undefinedSecondary"` in `_tryConnectAll`, causing template subscriptions to collide. Additionally `_tryDisconnectAll` was disconnecting by the wrong topic name (`"individualSecondary"` instead of the per-position names used by `_tryConnect`), so subscriptions for individual devices were never cleaned up.
+
+- Add `index < individualKeys.length` guard in `_tryConnectAll` for both cards
+- Rewrite `_tryDisconnectAll` to use the same per-position topic names as `_tryConnect`
+- Cap `entities.individual` at max 4 in the superstruct schema for both cards
+- Disable the "add entity" picker in `individual-row-editor` when already at 4 devices, and guard `_addEntity` server-side

--- a/packages/flixlix-cards/energy-flow-card-plus/src/energy-flow-card-plus.ts
+++ b/packages/flixlix-cards/energy-flow-card-plus/src/energy-flow-card-plus.ts
@@ -1276,7 +1276,8 @@ export class EnergyFlowCardPlus extends LitElement {
         if (Array.isArray(value)) {
           const individualKeys = ["left-top", "left-bottom", "right-top", "right-bottom"];
           value.forEach((template, index) => {
-            if (template) this._tryConnect(template, `${individualKeys[index]}Secondary`);
+            if (index < individualKeys.length && template)
+              this._tryConnect(template, `${individualKeys[index]}Secondary`);
           });
         } else {
           this._tryConnect(value, key);
@@ -1334,20 +1335,24 @@ export class EnergyFlowCardPlus extends LitElement {
 
   private async _tryDisconnectAll() {
     const { entities } = this._config;
-    const templatesObj = {
+    const scalarTopics = {
       gridSecondary: entities.grid?.secondary_info?.template,
       solarSecondary: entities.solar?.secondary_info?.template,
       homeSecondary: entities.home?.secondary_info?.template,
-      individualSecondary: entities.individual?.map(
-        (individual) => individual.secondary_info?.template
-      ),
     };
 
-    for (const [key, value] of Object.entries(templatesObj)) {
+    for (const [key, value] of Object.entries(scalarTopics)) {
       if (value) {
         this._tryDisconnect(key);
       }
     }
+
+    const individualKeys = ["left-top", "left-bottom", "right-top", "right-bottom"];
+    entities.individual?.forEach((individual, index) => {
+      if (index < individualKeys.length && individual.secondary_info?.template) {
+        this._tryDisconnect(`${individualKeys[index]}Secondary`);
+      }
+    });
   }
 
   private async _tryDisconnect(topic: string): Promise<void> {

--- a/packages/flixlix-cards/energy-flow-card-plus/src/ui-editor/schema/_schema-all.ts
+++ b/packages/flixlix-cards/energy-flow-card-plus/src/ui-editor/schema/_schema-all.ts
@@ -7,7 +7,18 @@ import { individualSchema } from "@flixlix-cards/shared/ui-editor/schema/individ
 import { solarSchema } from "@flixlix-cards/shared/ui-editor/schema/solar";
 import { mdiBatteryHigh, mdiHome, mdiLeaf, mdiTransmissionTower, mdiWeatherSunny } from "@mdi/js";
 import memoizeOne from "memoize-one";
-import { any, assign, boolean, integer, number, object, optional, string } from "superstruct";
+import {
+  any,
+  array,
+  assign,
+  boolean,
+  integer,
+  number,
+  object,
+  optional,
+  size,
+  string,
+} from "superstruct";
 
 const baseLovelaceCardConfig = object({
   type: string(),
@@ -55,7 +66,7 @@ export const cardConfigStruct = assign(
       solar: optional(any()),
       home: optional(any()),
       fossil_fuel_percentage: optional(any()),
-      individual: optional(any()),
+      individual: optional(size(array(any()), 0, 4)),
       individual1: optional(any()),
       individual2: optional(any()),
     }),

--- a/packages/flixlix-cards/power-flow-card-plus/__tests__/individual-template-topics.test.ts
+++ b/packages/flixlix-cards/power-flow-card-plus/__tests__/individual-template-topics.test.ts
@@ -1,0 +1,123 @@
+// Regression tests for individual-device template topic safety (plan 011)
+// A 5th+ individual must never produce an "undefinedSecondary" topic,
+// and disconnect must use the same per-position topic names as connect.
+
+import { assert, StructError } from "superstruct";
+import { describe, expect, test, vi } from "vitest";
+
+import { type PowerFlowCardPlusConfig } from "@flixlix-cards/shared/types";
+import { PowerFlowCardPlus } from "../src/power-flow-card-plus";
+import { cardConfigStruct } from "../src/ui-editor/schema/_schema-all";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeCard(individuals: object[]) {
+  const card = new PowerFlowCardPlus();
+  card.setConfig({
+    type: "custom:power-flow-card-plus",
+    entities: {
+      grid: { entity: "sensor.grid" },
+      individual: individuals,
+    },
+  } as unknown as PowerFlowCardPlusConfig);
+  return card;
+}
+
+function spyConnectTopics(card: PowerFlowCardPlus): string[] {
+  const topics: string[] = [];
+  (card as any)._tryConnect = vi.fn((template: string, topic: string) => {
+    topics.push(topic);
+  });
+  (card as any)._tryConnectAll();
+  return topics;
+}
+
+function spyDisconnectTopics(card: PowerFlowCardPlus): string[] {
+  const topics: string[] = [];
+  (card as any)._tryDisconnect = vi.fn((topic: string) => {
+    topics.push(topic);
+  });
+  (card as any)._tryDisconnectAll();
+  return topics;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("individual template topics", () => {
+  test("4 individuals with templates → 4 position topics, no undefined", () => {
+    const card = makeCard([
+      { entity: "sensor.i1", secondary_info: { template: "{{1}}" } },
+      { entity: "sensor.i2", secondary_info: { template: "{{2}}" } },
+      { entity: "sensor.i3", secondary_info: { template: "{{3}}" } },
+      { entity: "sensor.i4", secondary_info: { template: "{{4}}" } },
+    ]);
+    const topics = spyConnectTopics(card);
+    expect(topics).not.toContain("undefinedSecondary");
+    expect(topics).toContain("left-topSecondary");
+    expect(topics).toContain("left-bottomSecondary");
+    expect(topics).toContain("right-topSecondary");
+    expect(topics).toContain("right-bottomSecondary");
+  });
+
+  test("5 individuals with templates → still no undefinedSecondary topic", () => {
+    const card = makeCard([
+      { entity: "sensor.i1", secondary_info: { template: "{{1}}" } },
+      { entity: "sensor.i2", secondary_info: { template: "{{2}}" } },
+      { entity: "sensor.i3", secondary_info: { template: "{{3}}" } },
+      { entity: "sensor.i4", secondary_info: { template: "{{4}}" } },
+      { entity: "sensor.i5", secondary_info: { template: "{{5}}" } },
+    ]);
+    const topics = spyConnectTopics(card);
+    expect(topics).not.toContain("undefinedSecondary");
+    expect(topics.length).toBe(4); // only 4 templates subscribed
+  });
+
+  test("disconnect uses per-position topics that match connect topics", () => {
+    const card = makeCard([
+      { entity: "sensor.i1", secondary_info: { template: "{{1}}" } },
+      { entity: "sensor.i2", secondary_info: { template: "{{2}}" } },
+    ]);
+    const connectTopics = spyConnectTopics(card);
+    // Reset spy then check disconnect uses identical topics
+    const disconnectTopics = spyDisconnectTopics(card);
+    expect(disconnectTopics).toEqual(expect.arrayContaining(connectTopics));
+    expect(disconnectTopics).not.toContain("individualSecondary");
+  });
+
+  test("schema accepts up to 4 individuals", () => {
+    const config = {
+      type: "custom:power-flow-card-plus",
+      entities: {
+        grid: { entity: "sensor.grid" },
+        individual: [
+          { entity: "sensor.i1" },
+          { entity: "sensor.i2" },
+          { entity: "sensor.i3" },
+          { entity: "sensor.i4" },
+        ],
+      },
+    };
+    expect(() => assert(config, cardConfigStruct)).not.toThrow();
+  });
+
+  test("schema rejects 5 individuals", () => {
+    const config = {
+      type: "custom:power-flow-card-plus",
+      entities: {
+        grid: { entity: "sensor.grid" },
+        individual: [
+          { entity: "sensor.i1" },
+          { entity: "sensor.i2" },
+          { entity: "sensor.i3" },
+          { entity: "sensor.i4" },
+          { entity: "sensor.i5" },
+        ],
+      },
+    };
+    expect(() => assert(config, cardConfigStruct)).toThrow(StructError);
+  });
+});

--- a/packages/flixlix-cards/power-flow-card-plus/src/power-flow-card-plus.ts
+++ b/packages/flixlix-cards/power-flow-card-plus/src/power-flow-card-plus.ts
@@ -1078,7 +1078,8 @@ export class PowerFlowCardPlus extends LitElement {
         if (Array.isArray(value)) {
           const individualKeys = ["left-top", "left-bottom", "right-top", "right-bottom"];
           value.forEach((template, index) => {
-            if (template) this._tryConnect(template, `${individualKeys[index]}Secondary`);
+            if (index < individualKeys.length && template)
+              this._tryConnect(template, `${individualKeys[index]}Secondary`);
           });
         } else {
           this._tryConnect(value, key);
@@ -1136,20 +1137,24 @@ export class PowerFlowCardPlus extends LitElement {
 
   private async _tryDisconnectAll() {
     const { entities } = this._config;
-    const templatesObj = {
+    const scalarTopics = {
       gridSecondary: entities.grid?.secondary_info?.template,
       solarSecondary: entities.solar?.secondary_info?.template,
       homeSecondary: entities.home?.secondary_info?.template,
-      individualSecondary: entities.individual?.map(
-        (individual) => individual.secondary_info?.template
-      ),
     };
 
-    for (const [key, value] of Object.entries(templatesObj)) {
+    for (const [key, value] of Object.entries(scalarTopics)) {
       if (value) {
         this._tryDisconnect(key);
       }
     }
+
+    const individualKeys = ["left-top", "left-bottom", "right-top", "right-bottom"];
+    entities.individual?.forEach((individual, index) => {
+      if (index < individualKeys.length && individual.secondary_info?.template) {
+        this._tryDisconnect(`${individualKeys[index]}Secondary`);
+      }
+    });
   }
 
   private async _tryDisconnect(topic: string): Promise<void> {

--- a/packages/flixlix-cards/power-flow-card-plus/src/ui-editor/schema/_schema-all.ts
+++ b/packages/flixlix-cards/power-flow-card-plus/src/ui-editor/schema/_schema-all.ts
@@ -7,7 +7,18 @@ import { individualSchema } from "@flixlix-cards/shared/ui-editor/schema/individ
 import { solarSchema } from "@flixlix-cards/shared/ui-editor/schema/solar";
 import { mdiBatteryHigh, mdiHome, mdiLeaf, mdiTransmissionTower, mdiWeatherSunny } from "@mdi/js";
 import memoizeOne from "memoize-one";
-import { any, assign, boolean, integer, number, object, optional, string } from "superstruct";
+import {
+  any,
+  array,
+  assign,
+  boolean,
+  integer,
+  number,
+  object,
+  optional,
+  size,
+  string,
+} from "superstruct";
 
 const baseLovelaceCardConfig = object({
   type: string(),
@@ -53,7 +64,7 @@ export const cardConfigStruct = assign(
       solar: optional(any()),
       home: optional(any()),
       fossil_fuel_percentage: optional(any()),
-      individual: optional(any()),
+      individual: optional(size(array(any()), 0, 4)),
       individual1: optional(any()),
       individual2: optional(any()),
     }),

--- a/packages/shared/src/ui-editor/components/individual-row-editor.ts
+++ b/packages/shared/src/ui-editor/components/individual-row-editor.ts
@@ -156,6 +156,7 @@ export class IndividualRowEditor extends LitElement {
       <ha-entity-picker
         class="add-entity"
         .hass=${this.hass}
+        ?disabled=${(this.entities?.length ?? 0) >= 4}
         @value-changed=${this._addEntity}
       ></ha-entity-picker>
     `;
@@ -224,6 +225,9 @@ export class IndividualRowEditor extends LitElement {
   private async _addEntity(ev: CustomEvent): Promise<void> {
     const value = ev.detail.value;
     if (value === "") {
+      return;
+    }
+    if ((this.entities?.length ?? 0) >= 4) {
       return;
     }
 


### PR DESCRIPTION
Plan 011. Caps `individual` at 4 (schema `size(…,0,4)` + UI add-button disabled + subscribe/disconnect guards), preventing a broken `undefinedSecondary` topic for a 5th device.

**Reviewed:** 10 power (incl. new regression suite) + 7 energy tests pass. Also fixes a real latent bug — `_tryDisconnectAll` used a wrong topic key, so individual template subscriptions were never unsubscribed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)