### PR TITLE
perf: :zap: quantize flow-dot durations to 0.1s steps

### DIFF
--- a/.changeset/quantize-flow-durations.md
+++ b/.changeset/quantize-flow-durations.md
@@ -1,0 +1,6 @@
+---
+"power-flow-card-plus": patch
+"energy-flow-card-plus": patch
+---
+
+Perf: quantize flow animation durations to 0.1s steps so tiny power fluctuations no longer restart/resync the dot animations

--- a/packages/shared/__tests__/core-utils.test.ts
+++ b/packages/shared/__tests__/core-utils.test.ts
@@ -60,7 +60,49 @@ describe("core utils", () => {
       use_new_flow_rate_model: false,
     } as unknown as FlowCardPlusConfig;
 
-    expect(computeFlowRate(config, 25, 100)).toBeCloseTo(7.75, 10);
+    expect(computeFlowRate(config, 25, 100)).toBeCloseTo(7.8, 10);
+  });
+
+  test("computeFlowRate quantizes: nearby inputs map to the same duration", () => {
+    const config = {
+      max_expected_power: 100,
+      min_expected_power: 0,
+      max_flow_rate: 10,
+      min_flow_rate: 1,
+      use_new_flow_rate_model: true,
+    } as unknown as FlowCardPlusConfig;
+
+    // 50 W and 50.4 W should both map to 5.5 (within 0.1s bucket)
+    expect(computeFlowRate(config, 50, 0)).toBe(5.5);
+    expect(computeFlowRate(config, 50.4, 0)).toBe(5.5);
+  });
+
+  test("computeFlowRate output is always on the 0.1s grid", () => {
+    const config = {
+      max_expected_power: 100,
+      min_expected_power: 0,
+      max_flow_rate: 10,
+      min_flow_rate: 1,
+      use_new_flow_rate_model: true,
+    } as unknown as FlowCardPlusConfig;
+
+    for (const input of [0, 10, 25, 33, 50, 66, 75, 90, 100]) {
+      const v = computeFlowRate(config, input, 0);
+      expect(Math.round(v * 10) / 10).toBe(v);
+    }
+  });
+
+  test("computeFlowRate quantizes the non-finite fallback (max_flow_rate)", () => {
+    // min_expected_power === max_expected_power causes division by zero → non-finite
+    const config = {
+      max_expected_power: 50,
+      min_expected_power: 50,
+      max_flow_rate: 6.66,
+      min_flow_rate: 1,
+      use_new_flow_rate_model: true,
+    } as unknown as FlowCardPlusConfig;
+
+    expect(computeFlowRate(config, 50, 0)).toBe(6.7);
   });
 
   test("computeIndividualFlowRate returns value when entry is not false and value is provided", () => {

--- a/packages/shared/src/utils/compute-flow-rate.ts
+++ b/packages/shared/src/utils/compute-flow-rate.ts
@@ -27,6 +27,10 @@ const oldFlowRate = (config: FlowCardPlusConfig, value: number, total: number): 
   return max - ratio * (max - min);
 };
 
+/** Animation durations below 0.1s precision are visually identical; rounding
+ *  keeps the <animateMotion dur> attribute stable across small power flickers. */
+const quantizeDuration = (seconds: number): number => Math.round(seconds * 10) / 10;
+
 export const computeFlowRate = (
   config: FlowCardPlusConfig,
   value: number,
@@ -37,9 +41,9 @@ export const computeFlowRate = (
     ? newFlowRate(config, value)
     : oldFlowRate(config, value, total);
   if (!Number.isFinite(result)) {
-    return config.max_flow_rate;
+    return quantizeDuration(config.max_flow_rate);
   }
-  return result;
+  return quantizeDuration(result);
 };
 
 export const computeIndividualFlowRate = (entry?: boolean | number, value?: number): number => {


### PR DESCRIPTION
Plan 014. Rounds `computeFlowRate` output to 0.1s so tiny power fluctuations stop rewriting `<animateMotion dur>` and triggering the SMIL resync every tick.

**Reviewed:** 57 shared tests pass; `computeIndividualFlowRate` left untouched. Dependency of #017.

🤖 Generated with [Claude Code](https://claude.com/claude-code)