### PR TITLE
perf: :zap: pause flow animations off-screen + honor prefers-reduced-motion

### DIFF
--- a/.changeset/pause-offscreen-animations.md
+++ b/.changeset/pause-offscreen-animations.md
@@ -1,0 +1,6 @@
+---
+"energy-flow-card-plus": patch
+"power-flow-card-plus": patch
+---
+
+Perf: flow animations now pause while the card is off-screen, and the animated dots respect the OS reduced-motion preference (set `disable_dots: false` to force them on).

--- a/packages/flixlix-cards/energy-flow-card-plus/src/energy-flow-card-plus.ts
+++ b/packages/flixlix-cards/energy-flow-card-plus/src/energy-flow-card-plus.ts
@@ -112,11 +112,22 @@ export class EnergyFlowCardPlus extends LitElement {
   private _energyCollectionKey?: string;
   private readonly wideEnoughForFourIndividuals = 359;
   private _resizeObserver?: ResizeObserver;
+  private _intersectionObserver?: IntersectionObserver;
+  private _animationsPaused = false;
   private _handleVisibilityChange = () => {
     if (typeof document !== "undefined" && document.visibilityState === "visible") {
       this.requestUpdate();
     }
   };
+
+  private _applyAnimationPauseState(): void {
+    const svgs = this.shadowRoot?.querySelectorAll<SVGSVGElement>("svg") ?? [];
+    svgs.forEach((svg) => {
+      if (typeof svg.pauseAnimations !== "function") return; // jsdom / old browsers
+      if (this._animationsPaused) svg.pauseAnimations();
+      else svg.unpauseAnimations();
+    });
+  }
 
   @query("#battery-grid-flow") batteryGridFlow?: SVGSVGElement;
   @query("#battery-home-flow") batteryToHomeFlow?: SVGSVGElement;
@@ -199,6 +210,15 @@ export class EnergyFlowCardPlus extends LitElement {
     if (typeof document !== "undefined") {
       document.addEventListener("visibilitychange", this._handleVisibilityChange);
     }
+    if (typeof IntersectionObserver !== "undefined") {
+      this._intersectionObserver = new IntersectionObserver((entries) => {
+        const entry = entries[0];
+        if (!entry) return;
+        this._animationsPaused = !entry.isIntersecting;
+        this._applyAnimationPauseState();
+      });
+      this._intersectionObserver.observe(this);
+    }
     this._tryConnectAll();
     this._ensureEnergyPeriodListener();
     this._ensureFossilDataSubscription();
@@ -208,6 +228,8 @@ export class EnergyFlowCardPlus extends LitElement {
   public disconnectedCallback() {
     this._resizeObserver?.disconnect();
     this._resizeObserver = undefined;
+    this._intersectionObserver?.disconnect();
+    this._intersectionObserver = undefined;
     if (typeof document !== "undefined") {
       document.removeEventListener("visibilitychange", this._handleVisibilityChange);
     }
@@ -690,6 +712,9 @@ export class EnergyFlowCardPlus extends LitElement {
     }
 
     this._tryConnectAll();
+    if (this._animationsPaused) {
+      this._applyAnimationPauseState();
+    }
   }
 
   protected willUpdate(changedProps: PropertyValues): void {
@@ -1148,7 +1173,7 @@ export class EnergyFlowCardPlus extends LitElement {
           if (Number.isFinite(nextTime)) {
             flowSVGElement.setCurrentTime(nextTime);
           }
-          flowSVGElement.unpauseAnimations();
+          if (!this._animationsPaused) flowSVGElement.unpauseAnimations();
         }
         this.previousDur[flowName] = Number.isFinite(nextDur)
           ? (nextDur as number)

--- a/packages/flixlix-cards/power-flow-card-plus/src/power-flow-card-plus.ts
+++ b/packages/flixlix-cards/power-flow-card-plus/src/power-flow-card-plus.ts
@@ -99,11 +99,22 @@ export class PowerFlowCardPlus extends LitElement {
   @state() private _width = 0;
   private readonly wideEnoughForFourIndividuals = 359;
   private _resizeObserver?: ResizeObserver;
+  private _intersectionObserver?: IntersectionObserver;
+  private _animationsPaused = false;
   private _handleVisibilityChange = () => {
     if (typeof document !== "undefined" && document.visibilityState === "visible") {
       this.requestUpdate();
     }
   };
+
+  private _applyAnimationPauseState(): void {
+    const svgs = this.shadowRoot?.querySelectorAll<SVGSVGElement>("svg") ?? [];
+    svgs.forEach((svg) => {
+      if (typeof svg.pauseAnimations !== "function") return; // jsdom / old browsers
+      if (this._animationsPaused) svg.pauseAnimations();
+      else svg.unpauseAnimations();
+    });
+  }
 
   @query("#battery-grid-flow") batteryGridFlow?: SVGSVGElement;
   @query("#battery-home-flow") batteryToHomeFlow?: SVGSVGElement;
@@ -175,12 +186,23 @@ export class PowerFlowCardPlus extends LitElement {
     if (typeof document !== "undefined") {
       document.addEventListener("visibilitychange", this._handleVisibilityChange);
     }
+    if (typeof IntersectionObserver !== "undefined") {
+      this._intersectionObserver = new IntersectionObserver((entries) => {
+        const entry = entries[0];
+        if (!entry) return;
+        this._animationsPaused = !entry.isIntersecting;
+        this._applyAnimationPauseState();
+      });
+      this._intersectionObserver.observe(this);
+    }
     this._tryConnectAll();
   }
 
   public disconnectedCallback() {
     this._resizeObserver?.disconnect();
     this._resizeObserver = undefined;
+    this._intersectionObserver?.disconnect();
+    this._intersectionObserver = undefined;
     if (typeof document !== "undefined") {
       document.removeEventListener("visibilitychange", this._handleVisibilityChange);
     }
@@ -529,6 +551,9 @@ export class PowerFlowCardPlus extends LitElement {
     }
 
     this._tryConnectAll();
+    if (this._animationsPaused) {
+      this._applyAnimationPauseState();
+    }
   }
 
   protected willUpdate(changedProps: PropertyValues): void {
@@ -952,7 +977,7 @@ export class PowerFlowCardPlus extends LitElement {
           flowSVGElement.setCurrentTime(
             flowSVGElement.getCurrentTime() * (newDur[flowName] / this.previousDur[flowName])
           );
-          flowSVGElement.unpauseAnimations();
+          if (!this._animationsPaused) flowSVGElement.unpauseAnimations();
         }
         this.previousDur[flowName] = newDur[flowName];
       });

--- a/packages/shared/__tests__/core-utils.test.ts
+++ b/packages/shared/__tests__/core-utils.test.ts
@@ -1,11 +1,45 @@
-import { describe, expect, test } from "vitest";
+import { afterEach, describe, expect, test, vi } from "vitest";
 
 import { adjustZeroTolerance } from "../src/states/tolerance/base";
 import { type FlowCardPlusConfig } from "../src/types";
+import { checkShouldShowDots } from "../src/utils/check-should-show-dots";
 import { computeFlowRate, computeIndividualFlowRate } from "../src/utils/compute-flow-rate";
 import { displayValue } from "../src/utils/display-value";
 
 const thinSpace = `\u2009`;
+
+describe("checkShouldShowDots - prefers-reduced-motion", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  test("returns false when matchMedia reports prefers-reduced-motion: reduce", () => {
+    vi.stubGlobal("window", {
+      matchMedia: () => ({ matches: true }),
+    });
+    expect(checkShouldShowDots({} as FlowCardPlusConfig)).toBe(false);
+  });
+
+  test("returns true when disable_dots is false (explicit opt-in overrides reduced-motion)", () => {
+    vi.stubGlobal("window", {
+      matchMedia: () => ({ matches: true }),
+    });
+    expect(checkShouldShowDots({ disable_dots: false } as unknown as FlowCardPlusConfig)).toBe(
+      true
+    );
+  });
+
+  test("returns true when matchMedia reports no reduced-motion preference", () => {
+    vi.stubGlobal("window", {
+      matchMedia: () => ({ matches: false }),
+    });
+    expect(checkShouldShowDots({} as FlowCardPlusConfig)).toBe(true);
+  });
+
+  test("returns true in node env (no window stub)", () => {
+    expect(checkShouldShowDots({} as FlowCardPlusConfig)).toBe(true);
+  });
+});
 
 describe("core utils", () => {
   test("adjustZeroTolerance returns 0 for null/zero values", () => {

--- a/packages/shared/src/utils/check-should-show-dots.ts
+++ b/packages/shared/src/utils/check-should-show-dots.ts
@@ -4,6 +4,14 @@ export const checkShouldShowDots = (config: FlowCardPlusConfig) => {
   if (config.disable_dots === true) {
     return false;
   }
+  if (config.disable_dots !== false) {
+    if (
+      typeof window !== "undefined" &&
+      window.matchMedia?.("(prefers-reduced-motion: reduce)").matches
+    ) {
+      return false;
+    }
+  }
   if (typeof document !== "undefined" && document.visibilityState === "hidden") {
     return false;
   }


### PR DESCRIPTION
Plan 015. IntersectionObserver pauses the SVG timelines when the card scrolls out of view; `checkShouldShowDots` honors `prefers-reduced-motion` (`disable_dots: false` overrides).

**Reviewed:** 58 shared + 5/7 card tests; browser APIs feature-guarded; all unpause sites gated.
Touches the two card files — merge-coordinate with #005/#016.

🤖 Generated with [Claude Code](https://claude.com/claude-code)