### PR TITLE
perf: :zap: cache number formatter + ResizeObserver hygiene

### DIFF
--- a/.changeset/016-render-loop-micro-costs.md
+++ b/.changeset/016-render-loop-micro-costs.md
@@ -1,0 +1,6 @@
+---
+"power-flow-card-plus": patch
+"energy-flow-card-plus": patch
+---
+
+Perf: cache number formatters and stop re-attaching the resize observer on every update

--- a/packages/flixlix-cards/energy-flow-card-plus/src/energy-flow-card-plus.ts
+++ b/packages/flixlix-cards/energy-flow-card-plus/src/energy-flow-card-plus.ts
@@ -112,6 +112,7 @@ export class EnergyFlowCardPlus extends LitElement {
   private _energyCollectionKey?: string;
   private readonly wideEnoughForFourIndividuals = 359;
   private _resizeObserver?: ResizeObserver;
+  private _resizeObservedElement?: HTMLElement;
   private _handleVisibilityChange = () => {
     if (typeof document !== "undefined" && document.visibilityState === "visible") {
       this.requestUpdate();
@@ -208,6 +209,7 @@ export class EnergyFlowCardPlus extends LitElement {
   public disconnectedCallback() {
     this._resizeObserver?.disconnect();
     this._resizeObserver = undefined;
+    this._resizeObservedElement = undefined;
     if (typeof document !== "undefined") {
       document.removeEventListener("visibilitychange", this._handleVisibilityChange);
     }
@@ -671,7 +673,7 @@ export class EnergyFlowCardPlus extends LitElement {
     }
 
     const elem = this.shadowRoot?.querySelector("#energy-flow-card-plus") as HTMLElement | null;
-    if (elem) {
+    if (elem && this._resizeObservedElement !== elem) {
       if (!this._resizeObserver) {
         this._resizeObserver = new ResizeObserver((entries) => {
           const entry = entries[0];
@@ -682,11 +684,9 @@ export class EnergyFlowCardPlus extends LitElement {
           }
         });
       }
+      if (this._resizeObservedElement) this._resizeObserver.unobserve(this._resizeObservedElement);
       this._resizeObserver.observe(elem);
-      const width = Math.round(elem.getBoundingClientRect().width);
-      if (width !== this._width) {
-        this._width = width;
-      }
+      this._resizeObservedElement = elem;
     }
 
     this._tryConnectAll();

--- a/packages/flixlix-cards/power-flow-card-plus/src/power-flow-card-plus.ts
+++ b/packages/flixlix-cards/power-flow-card-plus/src/power-flow-card-plus.ts
@@ -99,6 +99,7 @@ export class PowerFlowCardPlus extends LitElement {
   @state() private _width = 0;
   private readonly wideEnoughForFourIndividuals = 359;
   private _resizeObserver?: ResizeObserver;
+  private _resizeObservedElement?: HTMLElement;
   private _handleVisibilityChange = () => {
     if (typeof document !== "undefined" && document.visibilityState === "visible") {
       this.requestUpdate();
@@ -181,6 +182,7 @@ export class PowerFlowCardPlus extends LitElement {
   public disconnectedCallback() {
     this._resizeObserver?.disconnect();
     this._resizeObserver = undefined;
+    this._resizeObservedElement = undefined;
     if (typeof document !== "undefined") {
       document.removeEventListener("visibilitychange", this._handleVisibilityChange);
     }
@@ -510,7 +512,7 @@ export class PowerFlowCardPlus extends LitElement {
     }
 
     const elem = this.shadowRoot?.querySelector("#power-flow-card-plus") as HTMLElement | null;
-    if (elem) {
+    if (elem && this._resizeObservedElement !== elem) {
       if (!this._resizeObserver) {
         this._resizeObserver = new ResizeObserver((entries) => {
           const entry = entries[0];
@@ -521,11 +523,9 @@ export class PowerFlowCardPlus extends LitElement {
           }
         });
       }
+      if (this._resizeObservedElement) this._resizeObserver.unobserve(this._resizeObservedElement);
       this._resizeObserver.observe(elem);
-      const width = Math.round(elem.getBoundingClientRect().width);
-      if (width !== this._width) {
-        this._width = width;
-      }
+      this._resizeObservedElement = elem;
     }
 
     this._tryConnectAll();

--- a/packages/shared/__tests__/core-utils.test.ts
+++ b/packages/shared/__tests__/core-utils.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "vitest";
 
+import { formatNumber } from "custom-card-helpers";
 import { adjustZeroTolerance } from "../src/states/tolerance/base";
 import { type FlowCardPlusConfig } from "../src/types";
 import { computeFlowRate, computeIndividualFlowRate } from "../src/utils/compute-flow-rate";
@@ -118,5 +119,52 @@ describe("core utils", () => {
     } as unknown as FlowCardPlusConfig;
     expect(displayValue(hass, config, -500, { accept_negative: false })).toBe(`500${thinSpace}W`);
     expect(displayValue(hass, config, -500, { accept_negative: true })).toBe(`-500${thinSpace}W`);
+  });
+
+  test("displayValue formatter parity — decimal_comma (de) — kilo path, cache-hit exercised", () => {
+    const locale = { language: "de", number_format: "decimal_comma", time_format: "24" } as any;
+    const hass = { locale } as any;
+    const config = {
+      type: "power-flow-card-plus",
+      kilo_decimals: 1,
+      base_decimals: 0,
+      kilo_threshold: 1000,
+    } as unknown as FlowCardPlusConfig;
+    // value=1234.5 → kilo path → rounded value = 1.2 (1 decimal)
+    const expected = `${formatNumber(1.2, locale)}${thinSpace}kW`;
+    // call twice to exercise cache hit
+    expect(displayValue(hass, config, 1234.5, {})).toBe(expected);
+    expect(displayValue(hass, config, 1234.5, {})).toBe(expected);
+  });
+
+  test("displayValue formatter parity — comma_decimal (en) — kilo path, cache-hit exercised", () => {
+    const locale = { language: "en", number_format: "comma_decimal", time_format: "12" } as any;
+    const hass = { locale } as any;
+    const config = {
+      type: "power-flow-card-plus",
+      kilo_decimals: 2,
+      base_decimals: 0,
+      kilo_threshold: 1000,
+    } as unknown as FlowCardPlusConfig;
+    // value=2500 → kilo path → rounded value = 2.5 (2 decimals)
+    const expected = `${formatNumber(2.5, locale)}${thinSpace}kW`;
+    // call twice to exercise cache hit
+    expect(displayValue(hass, config, 2500, {})).toBe(expected);
+    expect(displayValue(hass, config, 2500, {})).toBe(expected);
+  });
+
+  test("displayValue formatter parity — number_format none — delegates directly (no Intl)", () => {
+    const locale = { language: "en", number_format: "none", time_format: "12" } as any;
+    const hass = { locale } as any;
+    const config = {
+      type: "power-flow-card-plus",
+      kilo_decimals: 1,
+      base_decimals: 0,
+      kilo_threshold: 1000,
+    } as unknown as FlowCardPlusConfig;
+    // value=1500 → kilo path → rounded value = 1.5 (1 decimal)
+    const expected = `${formatNumber(1.5, locale)}${thinSpace}kW`;
+    expect(displayValue(hass, config, 1500, {})).toBe(expected);
+    expect(displayValue(hass, config, 1500, {})).toBe(expected);
   });
 });

--- a/packages/shared/src/utils/display-value.ts
+++ b/packages/shared/src/utils/display-value.ts
@@ -1,8 +1,26 @@
 import { type FlowCardPlusConfig } from "@flixlix-cards/shared/types";
 import { isEnergyCard } from "@flixlix-cards/shared/utils/is-energy-card";
-import { type HomeAssistant, formatNumber } from "custom-card-helpers";
+import { type HomeAssistant, formatNumber, numberFormatToLocale } from "custom-card-helpers";
 import { defaultValues } from "./get-default-config";
 import { isNumberValue, round } from "./utils";
+
+const numberFormatters = new Map<string, Intl.NumberFormat>();
+
+const formatDisplayNumber = (value: number, locale: HomeAssistant["locale"]): string => {
+  // "none" (and the no-Intl path) is cheap in formatNumber — delegate for exact parity.
+  if (!locale || locale.number_format === "none") return formatNumber(value, locale);
+  const key = `${locale.language}|${locale.number_format}`;
+  let formatter = numberFormatters.get(key);
+  if (!formatter) {
+    try {
+      formatter = new Intl.NumberFormat(numberFormatToLocale(locale), { maximumFractionDigits: 2 });
+    } catch {
+      formatter = new Intl.NumberFormat(undefined, { maximumFractionDigits: 2 });
+    }
+    numberFormatters.set(key, formatter);
+  }
+  return formatter.format(value);
+};
 
 /**
  *
@@ -54,7 +72,7 @@ export const displayValue = (
 
   const transformValue = (v: number) => (!accept_negative ? Math.abs(v) : v);
 
-  const v = formatNumber(
+  const v = formatDisplayNumber(
     transformValue(
       isMega
         ? round(valueInNumber / 1000000, decimalsToRound ?? 2)


### PR DESCRIPTION
Plan 016. Caches `Intl.NumberFormat` per locale (was constructed per value) and stops re-`observe()`/`getBoundingClientRect()` on every `updated()`.

**Reviewed:** 57 shared + 5/7 card tests, parity tests confirm identical output, `getBoundingClientRect` removed from `updated()`.
Touches the two card files — merge-coordinate with #005/#015.

🤖 Generated with [Claude Code](https://claude.com/claude-code)