### PR TITLE
perf: :zap: CSS Motion Path dots (Step-1 spike)

### DIFF
--- a/.changeset/fix-negative-flow-tolerance.md
+++ b/.changeset/fix-negative-flow-tolerance.md
@@ -1,0 +1,6 @@
+---
+"power-flow-card-plus": patch
+"energy-flow-card-plus": patch
+---
+
+Fix: individual devices with negative readings are no longer hidden when display_zero is off

--- a/.changeset/quantize-flow-durations.md
+++ b/.changeset/quantize-flow-durations.md
@@ -1,0 +1,6 @@
+---
+"power-flow-card-plus": patch
+"energy-flow-card-plus": patch
+---
+
+Perf: quantize flow animation durations to 0.1s steps so tiny power fluctuations no longer restart/resync the dot animations

--- a/packages/flixlix-cards/energy-flow-card-plus/__tests__/render.test.ts
+++ b/packages/flixlix-cards/energy-flow-card-plus/__tests__/render.test.ts
@@ -5,12 +5,75 @@ import { describe, expect, test } from "vitest";
 import { type EnergyFlowCardPlusConfig } from "@flixlix-cards/shared/types";
 import { EnergyFlowCardPlus } from "../src/energy-flow-card-plus";
 
-describe("render", () => {
-  (globalThis as any).ResizeObserver = class {
-    observe() {}
-    disconnect() {}
-  };
+// jsdom does not provide ResizeObserver; stub it so the card's `updated` hook doesn't throw
+(globalThis as any).ResizeObserver = class {
+  observe() {}
+  disconnect() {}
+  unobserve() {}
+};
 
+type HassState = { state: string; attributes: Record<string, unknown> };
+
+function makeHass(states: Record<string, string> = {}) {
+  const hassStates: Record<string, HassState> = {};
+  for (const [entityId, state] of Object.entries(states)) {
+    hassStates[entityId] = {
+      state,
+      attributes: { friendly_name: entityId, unit_of_measurement: "Wh" },
+    };
+  }
+  return {
+    localize: (key: string) => key,
+    locale: { language: "en", number_format: "comma_decimal" },
+    states: hassStates,
+    config: {},
+    user: { name: "test" },
+    connection: {},
+    callWS: async () => ({}),
+  } as any;
+}
+
+function makeCard(config: EnergyFlowCardPlusConfig, hass: ReturnType<typeof makeHass>) {
+  const card = new EnergyFlowCardPlus();
+  card.hass = hass;
+  card.setConfig(config);
+  card.connectedCallback();
+  return card as unknown as {
+    render: () => unknown;
+    _computeRenderData: () => {
+      grid: {
+        has: boolean;
+        state: {
+          fromGrid: number | null;
+          toGrid: number | null;
+          toBattery: number | null;
+          toHome: number | null;
+        };
+      };
+      solar: {
+        has: boolean;
+        state: {
+          total: number | null;
+          toHome: number | null;
+          toGrid: number | null;
+          toBattery: number | null;
+        };
+      };
+      battery: {
+        has: boolean | string;
+        state: {
+          fromBattery: number | null;
+          toBattery: number | null;
+          toGrid: number | null;
+          toHome: number | null;
+        };
+      };
+      individualObjs: Array<{ has: boolean; state: number | null }>;
+    };
+  };
+}
+
+describe("render", () => {
   const hass = {
     localize: (key: string) => key,
     states: {},
@@ -60,5 +123,80 @@ describe("render", () => {
     card.hass = hass;
     card.setConfig(config);
     expect((card as any)._energyCollectionKey).toBe("energy_living_room");
+  });
+});
+
+describe("_computeRenderData (energy card)", () => {
+  test("case 1: basic grid + solar split with known totals", () => {
+    // energy_date_selection: false → reads directly from hass.states (no growthMap needed)
+    const config = {
+      type: "custom:energy-flow-card-plus",
+      energy_date_selection: false,
+      entities: {
+        grid: { entity: "sensor.grid_energy" },
+        solar: { entity: "sensor.solar_energy" },
+      },
+    } as EnergyFlowCardPlusConfig;
+    const hass = makeHass({
+      "sensor.grid_energy": "300",
+      "sensor.solar_energy": "700",
+    });
+    const card = makeCard(config, hass);
+    const data = card._computeRenderData();
+
+    // Grid string entity → fromGrid uses getEnergyEntityStateLocal(entity), toGrid = 0
+    expect(data.grid.state.fromGrid).toBe(300);
+    expect(data.grid.state.toGrid).toBe(0);
+    // Solar total
+    expect(data.solar.state.total).toBe(700);
+    // Solar covers home: toHome = total - toGrid - toBattery = 700 - 0 - 0 = 700
+    expect(data.solar.state.toHome).toBe(700);
+    // Grid toHome = max(fromGrid - toBattery, 0) = max(300 - 0, 0) = 300
+    expect(data.grid.state.toHome).toBe(300);
+  });
+
+  test("case 2: tolerance zeroing via adjustZeroTolerance — grid below tolerance is zeroed", () => {
+    const config = {
+      type: "custom:energy-flow-card-plus",
+      energy_date_selection: false,
+      entities: {
+        grid: { entity: "sensor.grid_energy", display_zero_tolerance: 10 } as any,
+      },
+    } as EnergyFlowCardPlusConfig;
+    // 7Wh is below the 10Wh tolerance
+    const hass = makeHass({ "sensor.grid_energy": "7" });
+    const card = makeCard(config, hass);
+    const data = card._computeRenderData();
+
+    expect(data.grid.state.fromGrid).toBe(0);
+    // Dependency rule: fromGrid === 0 → toHome and toBattery also 0
+    expect(data.grid.state.toHome).toBe(0);
+    expect(data.grid.state.toBattery).toBe(0);
+  });
+
+  test("case 3: no-NaN guarantee — unavailable entity produces only numeric output", () => {
+    const config = {
+      type: "custom:energy-flow-card-plus",
+      energy_date_selection: false,
+      entities: {
+        grid: { entity: "sensor.grid_energy" },
+        solar: { entity: "sensor.solar_energy" },
+      },
+    } as EnergyFlowCardPlusConfig;
+    // Neither entity has a numeric state; growthMap not involved (energy_date_selection: false)
+    // getEntityState returns null → getEntityStateWh returns 0
+    const hass = makeHass({
+      "sensor.grid_energy": "unavailable",
+      "sensor.solar_energy": "unavailable",
+    });
+    const card = makeCard(config, hass);
+    const data = card._computeRenderData();
+
+    expect(Number.isNaN(data.grid.state.fromGrid)).toBe(false);
+    expect(Number.isNaN(data.grid.state.toGrid)).toBe(false);
+    expect(Number.isNaN(data.grid.state.toBattery)).toBe(false);
+    expect(Number.isNaN(data.grid.state.toHome)).toBe(false);
+    expect(Number.isNaN(data.solar.state.total)).toBe(false);
+    expect(Number.isNaN(data.solar.state.toHome)).toBe(false);
   });
 });

--- a/packages/flixlix-cards/power-flow-card-plus/__tests__/render.test.ts
+++ b/packages/flixlix-cards/power-flow-card-plus/__tests__/render.test.ts
@@ -5,6 +5,76 @@ import { describe, expect, test } from "vitest";
 import { type PowerFlowCardPlusConfig } from "@flixlix-cards/shared/types";
 import { PowerFlowCardPlus } from "../src/power-flow-card-plus";
 
+// jsdom does not provide ResizeObserver; stub it so the card's `updated` hook doesn't throw
+(globalThis as any).ResizeObserver = class {
+  observe() {}
+  disconnect() {}
+  unobserve() {}
+};
+
+type HassState = { state: string; attributes: Record<string, unknown> };
+
+function makeHass(states: Record<string, string> = {}) {
+  const hassStates: Record<string, HassState> = {};
+  for (const [entityId, state] of Object.entries(states)) {
+    hassStates[entityId] = {
+      state,
+      attributes: { friendly_name: entityId, unit_of_measurement: "W" },
+    };
+  }
+  return {
+    localize: (key: string) => key,
+    locale: { language: "en", number_format: "comma_decimal" },
+    states: hassStates,
+    config: {},
+    user: { name: "test" },
+    connection: {},
+  } as any;
+}
+
+function makeCard(config: PowerFlowCardPlusConfig, hass: ReturnType<typeof makeHass>) {
+  const card = new PowerFlowCardPlus();
+  card.setConfig(config);
+  card.hass = hass;
+  card.connectedCallback();
+  return card as unknown as {
+    render: () => unknown;
+    _computeRenderData: () => ReturnType<typeof computeRenderDataShape>;
+  };
+}
+
+// Used only as a type reference — actual return shape is inferred from _computeRenderData
+declare function computeRenderDataShape(): {
+  grid: {
+    has: boolean;
+    state: {
+      fromGrid: number | null;
+      toGrid: number | null;
+      toBattery: number | null;
+      toHome: number | null;
+    };
+  };
+  solar: {
+    has: boolean;
+    state: {
+      total: number | null;
+      toHome: number | null;
+      toGrid: number | null;
+      toBattery: number | null;
+    };
+  };
+  battery: {
+    has: boolean | string;
+    state: {
+      fromBattery: number | null;
+      toBattery: number | null;
+      toGrid: number | null;
+      toHome: number | null;
+    };
+  };
+  individualObjs: Array<{ has: boolean; state: number | null }>;
+};
+
 describe("render", () => {
   test("renders correctly", () => {
     const config = {
@@ -20,5 +90,108 @@ describe("render", () => {
     card.connectedCallback();
     const rendered = (card as unknown as { render: () => unknown }).render();
     expect(rendered).toBeTruthy();
+  });
+});
+
+describe("_computeRenderData", () => {
+  test("case 1: grid-only consumption — fromGrid is the entity value and toHome follows", () => {
+    const config = {
+      type: "custom:power-flow-card-plus",
+      entities: {
+        grid: { entity: "sensor.grid" },
+      },
+    } as PowerFlowCardPlusConfig;
+    const hass = makeHass({ "sensor.grid": "500" });
+    const card = makeCard(config, hass);
+    const data = card._computeRenderData();
+
+    expect(data.grid.state.fromGrid).toBe(500);
+    // toHome = max(fromGrid - toBattery, 0) = max(500 - 0, 0) = 500
+    expect(data.grid.state.toHome).toBe(500);
+    // No solar entity configured
+    expect(data.solar.has).toBe(false);
+    // No battery entity configured → battery.has is falsy
+    expect(data.battery.has).toBeFalsy();
+  });
+
+  test("case 2: solar covers home and grid is zero — dependency rule zeroes grid toHome", () => {
+    const config = {
+      type: "custom:power-flow-card-plus",
+      entities: {
+        grid: { entity: "sensor.grid" },
+        solar: { entity: "sensor.solar" },
+      },
+    } as PowerFlowCardPlusConfig;
+    // grid produces nothing (0W), solar produces 1000W
+    const hass = makeHass({ "sensor.grid": "0", "sensor.solar": "1000" });
+    const card = makeCard(config, hass);
+    const data = card._computeRenderData();
+
+    expect(data.solar.state.total).toBe(1000);
+    // fromGrid === 0 → the dependency rule at lines 791-794 forces toHome and toBattery to 0
+    expect(data.grid.state.fromGrid).toBe(0);
+    expect(data.grid.state.toHome).toBe(0);
+    expect(data.grid.state.toBattery).toBe(0);
+    // Solar covers all home consumption
+    expect(data.solar.state.toHome).toBe(1000);
+  });
+
+  test("case 3: tolerance zeroing — grid below tolerance is treated as 0", () => {
+    const config = {
+      type: "custom:power-flow-card-plus",
+      entities: {
+        grid: { entity: "sensor.grid", display_zero_tolerance: 5 } as any,
+      },
+    } as PowerFlowCardPlusConfig;
+    // 3W is below the 5W tolerance
+    const hass = makeHass({ "sensor.grid": "3" });
+    const card = makeCard(config, hass);
+    const data = card._computeRenderData();
+
+    expect(data.grid.state.fromGrid).toBe(0);
+    // Dependency rule: fromGrid === 0 → toHome and toBattery also zeroed
+    expect(data.grid.state.toHome).toBe(0);
+    expect(data.grid.state.toBattery).toBe(0);
+  });
+
+  test("case 4: negative individual entity stays visible (Plan 001 regression guard)", () => {
+    const config = {
+      type: "custom:power-flow-card-plus",
+      entities: {
+        grid: { entity: "sensor.grid" },
+        individual: [{ entity: "sensor.device" }],
+      },
+    } as PowerFlowCardPlusConfig;
+    // Individual state is negative; getIndividualState applies Math.abs so state === 50
+    const hass = makeHass({ "sensor.grid": "100", "sensor.device": "-50" });
+    const card = makeCard(config, hass);
+    const data = card._computeRenderData();
+
+    expect(data.individualObjs).toHaveLength(1);
+    const individual = data.individualObjs[0];
+    // has === true: the device is visible even with a negative raw state
+    expect(individual.has).toBe(true);
+    // getIndividualState returns Math.abs of the raw value
+    expect(individual.state).toBe(50);
+  });
+
+  test("case 5: unavailable entity — no NaN in grid state fields", () => {
+    const config = {
+      type: "custom:power-flow-card-plus",
+      entities: {
+        grid: { entity: "sensor.grid" },
+        solar: { entity: "sensor.solar" },
+      },
+    } as PowerFlowCardPlusConfig;
+    // "unavailable" is not a number; getEntityState returns null → getEntityStateWatts returns 0
+    const hass = makeHass({ "sensor.grid": "unavailable", "sensor.solar": "unavailable" });
+    const card = makeCard(config, hass);
+    const data = card._computeRenderData();
+
+    expect(Number.isNaN(data.grid.state.fromGrid)).toBe(false);
+    expect(Number.isNaN(data.grid.state.toGrid)).toBe(false);
+    expect(Number.isNaN(data.grid.state.toBattery)).toBe(false);
+    expect(Number.isNaN(data.grid.state.toHome)).toBe(false);
+    expect(Number.isNaN(data.solar.state.total)).toBe(false);
   });
 });

--- a/packages/shared/__tests__/core-utils.test.ts
+++ b/packages/shared/__tests__/core-utils.test.ts
@@ -60,7 +60,49 @@ describe("core utils", () => {
       use_new_flow_rate_model: false,
     } as unknown as FlowCardPlusConfig;
 
-    expect(computeFlowRate(config, 25, 100)).toBeCloseTo(7.75, 10);
+    expect(computeFlowRate(config, 25, 100)).toBeCloseTo(7.8, 10);
+  });
+
+  test("computeFlowRate quantizes: nearby inputs map to the same duration", () => {
+    const config = {
+      max_expected_power: 100,
+      min_expected_power: 0,
+      max_flow_rate: 10,
+      min_flow_rate: 1,
+      use_new_flow_rate_model: true,
+    } as unknown as FlowCardPlusConfig;
+
+    // 50 W and 50.4 W should both map to 5.5 (within 0.1s bucket)
+    expect(computeFlowRate(config, 50, 0)).toBe(5.5);
+    expect(computeFlowRate(config, 50.4, 0)).toBe(5.5);
+  });
+
+  test("computeFlowRate output is always on the 0.1s grid", () => {
+    const config = {
+      max_expected_power: 100,
+      min_expected_power: 0,
+      max_flow_rate: 10,
+      min_flow_rate: 1,
+      use_new_flow_rate_model: true,
+    } as unknown as FlowCardPlusConfig;
+
+    for (const input of [0, 10, 25, 33, 50, 66, 75, 90, 100]) {
+      const v = computeFlowRate(config, input, 0);
+      expect(Math.round(v * 10) / 10).toBe(v);
+    }
+  });
+
+  test("computeFlowRate quantizes the non-finite fallback (max_flow_rate)", () => {
+    // min_expected_power === max_expected_power causes division by zero → non-finite
+    const config = {
+      max_expected_power: 50,
+      min_expected_power: 50,
+      max_flow_rate: 6.66,
+      min_flow_rate: 1,
+      use_new_flow_rate_model: true,
+    } as unknown as FlowCardPlusConfig;
+
+    expect(computeFlowRate(config, 50, 0)).toBe(6.7);
   });
 
   test("computeIndividualFlowRate returns value when entry is not false and value is provided", () => {

--- a/packages/shared/__tests__/tolerance.test.ts
+++ b/packages/shared/__tests__/tolerance.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from "vitest";
+
+import { hasIndividualObject } from "../src/states/raw/individual/has-individual-object";
+import { adjustZeroTolerance, isAboveTolerance } from "../src/states/tolerance/base";
+
+describe("adjustZeroTolerance", () => {
+  test("null input returns 0", () => {
+    expect(adjustZeroTolerance(null, 5)).toBe(0);
+  });
+
+  test("zero input returns 0", () => {
+    expect(adjustZeroTolerance(0, 5)).toBe(0);
+  });
+
+  test("positive below tolerance returns 0", () => {
+    expect(adjustZeroTolerance(0.5, 5)).toBe(0);
+  });
+
+  test("positive at/above tolerance returns value", () => {
+    expect(adjustZeroTolerance(7, 5)).toBe(7);
+  });
+
+  test("no tolerance returns value unchanged", () => {
+    expect(adjustZeroTolerance(7, undefined)).toBe(7);
+  });
+
+  test("negative above tolerance (regression: should return -50, not 0)", () => {
+    expect(adjustZeroTolerance(-50, 5)).toBe(-50);
+  });
+
+  test("negative below tolerance returns 0", () => {
+    expect(adjustZeroTolerance(-0.5, 5)).toBe(0);
+  });
+});
+
+describe("isAboveTolerance", () => {
+  test("zero value returns false", () => {
+    expect(isAboveTolerance(0, 0)).toBe(false);
+  });
+
+  test("negative value above tolerance magnitude (regression: should return true)", () => {
+    expect(isAboveTolerance(-50, 0)).toBe(true);
+  });
+});
+
+describe("hasIndividualObject", () => {
+  test("negative state above tolerance is visible (user-visible bug regression)", () => {
+    expect(hasIndividualObject(false, -50, 0)).toBe(true);
+  });
+});

--- a/packages/shared/src/components/flows/grid-to-home.ts
+++ b/packages/shared/src/components/flows/grid-to-home.ts
@@ -13,15 +13,14 @@ import { type Flows } from "./index";
 const gridToHomeDot = (
   config: FlowCardPlusConfig,
   grid: Flows["grid"],
-  newDur: Flows["newDur"]
+  newDur: Flows["newDur"],
+  pathD: string
 ) => {
   if (!checkShouldShowDots(config) || !grid.state.toHome) return nothing;
 
-  return svg`<circle r="1" class="grid" vector-effect="non-scaling-stroke">
-      <animateMotion dur="${newDur.gridToHome}s" repeatCount="indefinite" calcMode="paced">
-        <mpath xlink:href="#grid" />
-      </animateMotion>
-    </circle>`;
+  return svg`<circle r="1" class="grid flow-dot"
+    style="offset-path: path('${pathD}'); animation-duration: ${newDur.gridToHome}s;"
+    vector-effect="non-scaling-stroke"></circle>`;
 };
 
 export const flowGridToHome = (
@@ -31,6 +30,8 @@ export const flowGridToHome = (
   const shouldShow =
     grid.has && showLine(config, grid.state.fromGrid) && !config.entities.home?.hide;
   if (!shouldShow) return nothing;
+
+  const gridToHomePathD = `M0,${battery.has ? 50 : solar.has ? 56 : 53} H100`;
 
   return html`<div
     class="lines ${classMap({
@@ -49,10 +50,10 @@ export const flowGridToHome = (
       <path
         class="grid ${styleLine(grid.state.toHome || 0, config)}"
         id="grid"
-        d="M0,${battery.has ? 50 : solar.has ? 56 : 53} H100"
+        d="${gridToHomePathD}"
         vector-effect="non-scaling-stroke"
       ></path>
-      ${gridToHomeDot(config, grid, newDur)}
+      ${gridToHomeDot(config, grid, newDur, gridToHomePathD)}
     </svg>
   </div>`;
 };

--- a/packages/shared/src/states/tolerance/base.ts
+++ b/packages/shared/src/states/tolerance/base.ts
@@ -1,5 +1,5 @@
 export const isAboveTolerance = (value: number | null, tolerance: number): boolean =>
-  !!value && value >= tolerance;
+  value !== null && value !== 0 && Math.abs(value) >= tolerance;
 
 export const adjustZeroTolerance = (
   value: number | null,

--- a/packages/shared/src/style/index.ts
+++ b/packages/shared/src/style/index.ts
@@ -588,6 +588,21 @@ export const styles = css`
     }
   }
 
+  .flow-dot {
+    animation-name: flow-dot-travel;
+    animation-timing-function: linear;
+    animation-iteration-count: infinite;
+  }
+
+  @keyframes flow-dot-travel {
+    from {
+      offset-distance: 0%;
+    }
+    to {
+      offset-distance: 100%;
+    }
+  }
+
   .card-actions {
     display: flex;
     justify-content: space-between;

--- a/packages/shared/src/utils/compute-flow-rate.ts
+++ b/packages/shared/src/utils/compute-flow-rate.ts
@@ -27,6 +27,10 @@ const oldFlowRate = (config: FlowCardPlusConfig, value: number, total: number): 
   return max - ratio * (max - min);
 };
 
+/** Animation durations below 0.1s precision are visually identical; rounding
+ *  keeps the <animateMotion dur> attribute stable across small power flickers. */
+const quantizeDuration = (seconds: number): number => Math.round(seconds * 10) / 10;
+
 export const computeFlowRate = (
   config: FlowCardPlusConfig,
   value: number,
@@ -37,9 +41,9 @@ export const computeFlowRate = (
     ? newFlowRate(config, value)
     : oldFlowRate(config, value, total);
   if (!Number.isFinite(result)) {
-    return config.max_flow_rate;
+    return quantizeDuration(config.max_flow_rate);
   }
-  return result;
+  return quantizeDuration(result);
 };
 
 export const computeIndividualFlowRate = (entry?: boolean | number, value?: number): number => {


### PR DESCRIPTION
Plan 017. Replaces SMIL `<animateMotion>` with compositor-friendly CSS `offset-path`/`offset-distance`. **Spike only** — converts the `grid-to-home` flow + adds keyframes; compiles & tests pass.

> 🚧 **DRAFT — go/no-go gate.** The plan requires verifying the dot in **Chrome + Firefox + Safari** (offset-path on SVG children is the open question) before converting the remaining flows (Steps 2–6). A headless run can't do that. **Depends on #004 + #014** (branch includes their commits).

🤖 Generated with [Claude Code](https://claude.com/claude-code)