### PR TITLE
Allow negative individual power values

### DIFF
--- a/.changeset/allow-bidirectional-individuals.md
+++ b/.changeset/allow-bidirectional-individuals.md
@@ -1,0 +1,6 @@
+---
+"@flixlix-cards/shared": patch
+"power-flow-card-plus": patch
+---
+
+Add bidirectional individual device support to power-flow-card-plus.

--- a/packages/flixlix-cards/power-flow-card-plus/__tests__/render.test.ts
+++ b/packages/flixlix-cards/power-flow-card-plus/__tests__/render.test.ts
@@ -5,6 +5,8 @@ import { describe, expect, test } from "vitest";
 import { type PowerFlowCardPlusConfig } from "@flixlix-cards/shared/types";
 import { PowerFlowCardPlus } from "../src/power-flow-card-plus";
 
+const thinSpace = `\u2009`;
+
 // jsdom does not provide ResizeObserver; stub it so the card's `updated` hook doesn't throw
 (globalThis as any).ResizeObserver = class {
   observe() {}
@@ -72,7 +74,10 @@ declare function computeRenderDataShape(): {
       toHome: number | null;
     };
   };
-  individualObjs: Array<{ has: boolean; state: number | null }>;
+  individualObjs: Array<{ has: boolean; invertAnimation: boolean; state: number | null }>;
+  homeGridCircumference: number;
+  homeIndividualCircumference: number;
+  homeUsageToDisplay: string;
 };
 
 describe("render", () => {
@@ -154,7 +159,7 @@ describe("_computeRenderData", () => {
     expect(data.grid.state.toBattery).toBe(0);
   });
 
-  test("case 4: negative individual entity stays visible (Plan 001 regression guard)", () => {
+  test("case 4: positive individual entity becomes home flow", () => {
     const config = {
       type: "custom:power-flow-card-plus",
       entities: {
@@ -162,17 +167,70 @@ describe("_computeRenderData", () => {
         individual: [{ entity: "sensor.device" }],
       },
     } as PowerFlowCardPlusConfig;
-    // Individual state is negative; getIndividualState applies Math.abs so state === 50
-    const hass = makeHass({ "sensor.grid": "100", "sensor.device": "-50" });
+    const hass = makeHass({ "sensor.grid": "100", "sensor.device": "50" });
     const card = makeCard(config, hass);
     const data = card._computeRenderData();
 
     expect(data.individualObjs).toHaveLength(1);
     const individual = data.individualObjs[0];
-    // has === true: the device is visible even with a negative raw state
     expect(individual.has).toBe(true);
-    // getIndividualState returns Math.abs of the raw value
     expect(individual.state).toBe(50);
+    expect(individual.invertAnimation).toBe(true);
+  });
+
+  test("case 4b: separated individual entities use production as negative flow", () => {
+    const config = {
+      type: "custom:power-flow-card-plus",
+      entities: {
+        grid: { entity: "sensor.grid" },
+        individual: [
+          {
+            entity: {
+              consumption: "sensor.ecoflow_consumption",
+              production: "sensor.ecoflow_production",
+            },
+          },
+        ],
+      },
+    } as PowerFlowCardPlusConfig;
+    const hass = makeHass({
+      "sensor.grid": "100",
+      "sensor.ecoflow_consumption": "0",
+      "sensor.ecoflow_production": "250",
+    });
+    const card = makeCard(config, hass);
+    const data = card._computeRenderData();
+
+    expect(data.individualObjs).toHaveLength(1);
+    const individual = data.individualObjs[0];
+    expect(individual.has).toBe(true);
+    expect(individual.state).toBe(-250);
+    expect(individual.invertAnimation).toBe(false);
+  });
+
+  test("case 4c: discharging individual flow is added to home usage", () => {
+    const config = {
+      type: "custom:power-flow-card-plus",
+      entities: {
+        grid: { entity: "sensor.grid" },
+        home: { entity: "sensor.home", subtract_individual: true },
+        individual: [
+          {
+            entity: "sensor.stream_ultra",
+          },
+        ],
+      },
+    } as PowerFlowCardPlusConfig;
+    const hass = makeHass({
+      "sensor.grid": "3",
+      "sensor.home": "0",
+      "sensor.stream_ultra": "104",
+    });
+    const card = makeCard(config, hass);
+    const data = card._computeRenderData();
+
+    expect(data.homeUsageToDisplay).toBe(`107${thinSpace}W`);
+    expect(data.homeIndividualCircumference).toBeGreaterThan(data.homeGridCircumference);
   });
 
   test("case 5: unavailable entity — no NaN in grid state fields", () => {

--- a/packages/flixlix-cards/power-flow-card-plus/src/power-flow-card-plus.ts
+++ b/packages/flixlix-cards/power-flow-card-plus/src/power-flow-card-plus.ts
@@ -123,6 +123,7 @@ export class PowerFlowCardPlus extends LitElement {
         newDur: NewDur;
         templatesObj: TemplatesObj;
         homeBatteryCircumference: number;
+        homeIndividualCircumference: number;
         homeSolarCircumference: number;
         homeNonFossilCircumference: number;
         homeGridCircumference: number;
@@ -369,6 +370,7 @@ export class PowerFlowCardPlus extends LitElement {
       newDur,
       templatesObj,
       homeBatteryCircumference,
+      homeIndividualCircumference,
       homeGridCircumference,
       homeNonFossilCircumference,
       homeSolarCircumference,
@@ -457,6 +459,7 @@ export class PowerFlowCardPlus extends LitElement {
                   grid,
                   home,
                   homeBatteryCircumference,
+                  homeIndividualCircumference,
                   homeGridCircumference,
                   homeNonFossilCircumference,
                   homeSolarCircumference,
@@ -827,34 +830,50 @@ export class PowerFlowCardPlus extends LitElement {
       nonFossil.state.power = 0;
     }
     const totalIndividualConsumption =
-      individualObjs?.reduce((a, b) => a + (b.has ? b.state || 0 : 0), 0) || 0;
+      individualObjs?.reduce(
+        (a, b) => a + (b.has && !b.invertAnimation ? Math.abs(b.state || 0) : 0),
+        0
+      ) || 0;
+    const totalIndividualToHome =
+      individualObjs?.reduce(
+        (a, b) => a + (b.has && b.invertAnimation ? Math.abs(b.state || 0) : 0),
+        0
+      ) || 0;
+    const totalIndividualFlow = totalIndividualConsumption + totalIndividualToHome;
     const totalHomeConsumption = Math.max(
       (grid.state.toHome ?? 0) + (solar.state.toHome ?? 0) + (battery.state.toHome ?? 0),
       0
     );
+    const totalHomeSourceConsumption = totalHomeConsumption + totalIndividualToHome;
     const homeBatteryCircumference = battery.state.toHome
-      ? CIRCLE_CIRCUMFERENCE * (battery.state.toHome / totalHomeConsumption)
+      ? CIRCLE_CIRCUMFERENCE * (battery.state.toHome / totalHomeSourceConsumption)
       : 0;
     const homeSolarCircumference = solar.state.toHome
-      ? CIRCLE_CIRCUMFERENCE * (solar.state.toHome / totalHomeConsumption)
+      ? CIRCLE_CIRCUMFERENCE * (solar.state.toHome / totalHomeSourceConsumption)
+      : 0;
+    const homeIndividualCircumference = totalIndividualToHome
+      ? CIRCLE_CIRCUMFERENCE * (totalIndividualToHome / totalHomeSourceConsumption)
       : 0;
     const homeNonFossilCircumference = nonFossil.state.power
-      ? CIRCLE_CIRCUMFERENCE * (nonFossil.state.power / totalHomeConsumption)
+      ? CIRCLE_CIRCUMFERENCE * (nonFossil.state.power / totalHomeSourceConsumption)
       : 0;
     const homeGridCircumference =
       CIRCLE_CIRCUMFERENCE *
-      ((totalHomeConsumption -
+      ((totalHomeSourceConsumption -
         (nonFossil.state.power ?? 0) -
         (battery.state.toHome ?? 0) -
-        (solar.state.toHome ?? 0)) /
-        totalHomeConsumption);
+        (solar.state.toHome ?? 0) -
+        totalIndividualToHome) /
+        totalHomeSourceConsumption);
     const homeUsageToDisplay =
       entities.home?.override_state && entities.home.entity
         ? entities.home?.subtract_individual
           ? displayValue(
               this.hass,
               this._config,
-              getEntityStateWatts(this.hass, entities.home.entity) - totalIndividualConsumption,
+              getEntityStateWatts(this.hass, entities.home.entity) -
+                totalIndividualConsumption +
+                totalIndividualToHome,
               {
                 unit: entities.home?.unit_of_measurement,
                 unitWhiteSpace: entities.home?.unit_white_space,
@@ -873,7 +892,7 @@ export class PowerFlowCardPlus extends LitElement {
           ? displayValue(
               this.hass,
               this._config,
-              totalHomeConsumption - totalIndividualConsumption || 0,
+              totalHomeConsumption - totalIndividualConsumption + totalIndividualToHome || 0,
               {
                 unit: entities.home?.unit_of_measurement,
                 unitWhiteSpace: entities.home?.unit_white_space,
@@ -921,7 +940,7 @@ export class PowerFlowCardPlus extends LitElement {
       solarToHome: computeFlowRate(this._config, solar.state.toHome ?? 0, totalLines),
       individual:
         individualObjs?.map((individual) =>
-          computeFlowRate(this._config, individual.state ?? 0, totalIndividualConsumption)
+          computeFlowRate(this._config, Math.abs(individual.state ?? 0), totalIndividualFlow)
         ) || [],
       nonFossil: computeFlowRate(this._config, nonFossil.state.power ?? 0, totalLines),
     };
@@ -976,10 +995,14 @@ export class PowerFlowCardPlus extends LitElement {
         value: homeNonFossilCircumference,
         color: "var(--energy-non-fossil-color)",
       },
+      individual: {
+        value: homeIndividualCircumference,
+        color: "var(--home-individual-color)",
+      },
     };
-    const homeSourceKeys = Object.keys(homeSources) as (keyof HomeSources)[];
+    const homeSourceKeys = Object.keys(homeSources) as Array<keyof typeof homeSources>;
     const homeLargestSource = homeSourceKeys.reduce((a, b) =>
-      homeSources[a].value > homeSources[b].value ? a : b
+      homeSources[a]!.value > homeSources[b]!.value ? a : b
     );
     const individualKeys = ["left-top", "left-bottom", "right-top", "right-bottom"];
     const templatesObj: TemplatesObj = {
@@ -1049,6 +1072,7 @@ export class PowerFlowCardPlus extends LitElement {
       newDur,
       templatesObj,
       homeBatteryCircumference,
+      homeIndividualCircumference,
       homeSolarCircumference,
       homeNonFossilCircumference,
       homeGridCircumference,

--- a/packages/shared/src/components/home.ts
+++ b/packages/shared/src/components/home.ts
@@ -19,6 +19,7 @@ interface Home {
   homeSolarCircumference: number;
   CIRCLE_CIRCUMFERENCE: number;
   homeBatteryCircumference: number;
+  homeIndividualCircumference?: number;
   homeNonFossilCircumference: number;
   homeGridCircumference: number;
   individual: IndividualObject[];
@@ -35,6 +36,7 @@ export const homeElement = (
     homeSolarCircumference,
     CIRCLE_CIRCUMFERENCE,
     homeBatteryCircumference,
+    homeIndividualCircumference,
     homeNonFossilCircumference,
     homeGridCircumference,
     individual,
@@ -117,6 +119,22 @@ export const homeElement = (
                   homeNonFossilCircumference}"
                   stroke-dashoffset="-${CIRCLE_CIRCUMFERENCE -
                   homeNonFossilCircumference -
+                  (homeBatteryCircumference || 0) -
+                  (homeSolarCircumference || 0)}"
+                  shape-rendering="geometricPrecision"
+                />`
+            : nothing}
+          ${homeIndividualCircumference
+            ? svg`<circle
+                  class="individual-home"
+                  cx="40"
+                  cy="40"
+                  r="38"
+                  stroke-dasharray="${homeIndividualCircumference} ${CIRCLE_CIRCUMFERENCE -
+                  homeIndividualCircumference}"
+                  stroke-dashoffset="-${CIRCLE_CIRCUMFERENCE -
+                  homeIndividualCircumference -
+                  (homeNonFossilCircumference || 0) -
                   (homeBatteryCircumference || 0) -
                   (homeSolarCircumference || 0)}"
                   shape-rendering="geometricPrecision"

--- a/packages/shared/src/components/individual-left-bottom-element.ts
+++ b/packages/shared/src/components/individual-left-bottom-element.ts
@@ -28,20 +28,22 @@ export const individualLeftBottomElement = (
   if (!individualObj) return spacer;
   const disableEntityClick = config.clickable_entities === false;
   const indexOfIndividual =
-    config?.entities?.individual?.findIndex((e) => e.entity === individualObj.entity) || 0;
+    config?.entities?.individual?.findIndex((e) => e === individualObj.field) || 0;
   const duration = newDur.individual[indexOfIndividual] || 0;
+  const individualAbsState = Math.abs(individualObj.state || 0);
+  const shouldShowDirection =
+    individualObj?.showDirection && individualAbsState > (individualObj.displayZeroTolerance ?? 0);
   return html`<div class="circle-container individual-bottom bottom">
-    ${showLine(config, individualObj?.state || 0) && !config.entities.home?.hide
+    ${showLine(config, individualAbsState) && !config.entities.home?.hide
       ? html`
           <svg width="80" height="30">
             <path
               d="M40 40 v-40"
               id="individual-bottom"
-              class="${styleLine(individualObj?.state || 0, config)}"
+              class="${styleLine(individualAbsState, config)}"
             />
             ${checkShouldShowDots(config) &&
-            individualObj?.state &&
-            individualObj.state >= (individualObj.displayZeroTolerance ?? 0)
+            individualAbsState > (individualObj.displayZeroTolerance ?? 0)
               ? svg`<circle r="1.75" class="individual-bottom" vector-effect="non-scaling-stroke">
                     <animateMotion
                       dur="${computeIndividualFlowRate(
@@ -97,9 +99,9 @@ export const individualLeftBottomElement = (
         ? html` <ha-icon id="individual-left-bottom-icon" .icon=${individualObj?.icon}></ha-icon>`
         : nothing}
       ${individualObj?.field?.display_zero_state !== false ||
-      (individualObj?.state || 0) > (individualObj.displayZeroTolerance ?? 0)
+      individualAbsState > (individualObj.displayZeroTolerance ?? 0)
         ? html` <span class="individual-bottom individual-left-bottom"
-            >${individualObj?.showDirection
+            >${shouldShowDirection
               ? html`<ha-icon
                   class="small"
                   .icon=${individualObj?.invertAnimation ? "mdi:arrow-up" : "mdi:arrow-down"}

--- a/packages/shared/src/components/individual-left-top-element.ts
+++ b/packages/shared/src/components/individual-left-top-element.ts
@@ -28,8 +28,11 @@ export const individualLeftTopElement = (
   if (!individualObj) return spacer;
   const disableEntityClick = config.clickable_entities === false;
   const indexOfIndividual =
-    config?.entities?.individual?.findIndex((e) => e.entity === individualObj.entity) || 0;
+    config?.entities?.individual?.findIndex((e) => e === individualObj.field) || 0;
   const duration = newDur.individual[indexOfIndividual] || 0;
+  const individualAbsState = Math.abs(individualObj.state || 0);
+  const shouldShowDirection =
+    individualObj?.showDirection && individualAbsState > (individualObj.displayZeroTolerance ?? 0);
   return html`<div class="circle-container individual-top">
     <span class="label">${individualObj.name}</span>
     <div
@@ -69,28 +72,27 @@ export const individualLeftTopElement = (
         ? html` <ha-icon id="individual-left-top-icon" .icon=${individualObj.icon}></ha-icon>`
         : nothing}
       ${individualObj?.field?.display_zero_state !== false ||
-      (individualObj.state || 0) > (individualObj.displayZeroTolerance ?? 0)
+      individualAbsState > (individualObj.displayZeroTolerance ?? 0)
         ? html` <span class="individual-top individual-left-top">
-            ${individualObj?.showDirection
+            ${shouldShowDirection
               ? html`<ha-icon
                   class="small"
-                  .icon=${individualObj.invertAnimation ? "mdi:arrow-down" : "mdi:arrow-up"}
+                  .icon=${individualObj.invertAnimation ? "mdi:arrow-up" : "mdi:arrow-down"}
                 ></ha-icon>`
               : nothing}${displayState}
           </span>`
         : nothing}
     </div>
-    ${showLine(config, individualObj.state || 0) && !config.entities.home?.hide
+    ${showLine(config, individualAbsState) && !config.entities.home?.hide
       ? html`
           <svg width="80" height="30">
             <path
               d="M40 -10 v50"
               id="individual-top"
-              class="${styleLine(individualObj.state || 0, config)}"
+              class="${styleLine(individualAbsState, config)}"
             />
             ${checkShouldShowDots(config) &&
-            individualObj.state &&
-            individualObj.state >= (individualObj.displayZeroTolerance ?? 0)
+            individualAbsState > (individualObj.displayZeroTolerance ?? 0)
               ? svg`<circle r="1.75" class="individual-top" vector-effect="non-scaling-stroke">
                     <animateMotion
                       dur="${computeIndividualFlowRate(

--- a/packages/shared/src/components/individual-right-bottom-element.ts
+++ b/packages/shared/src/components/individual-right-bottom-element.ts
@@ -29,11 +29,14 @@ export const individualRightBottomElement = (
   const disableEntityClick = config.clickable_entities === false;
 
   const indexOfIndividual = config?.entities?.individual?.findIndex(
-    (e) => e.entity === individualObj.entity
+    (e) => e === individualObj.field
   );
   if (indexOfIndividual === -1 || indexOfIndividual === undefined) return spacer;
 
   const duration = newDur.individual[indexOfIndividual] || 1.66;
+  const individualAbsState = Math.abs(individualObj.state || 0);
+  const shouldShowDirection =
+    individualObj?.showDirection && individualAbsState > (individualObj.displayZeroTolerance ?? 0);
 
   return html`<div
     class="circle-container individual-bottom individual-right individual-right-bottom"
@@ -75,19 +78,19 @@ export const individualRightBottomElement = (
         ? html` <ha-icon id="individual-right-bottom-icon" .icon=${individualObj.icon}></ha-icon>`
         : nothing}
       ${individualObj?.field?.display_zero_state !== false ||
-      (individualObj.state || 0) > (individualObj.displayZeroTolerance ?? 0)
+      individualAbsState > (individualObj.displayZeroTolerance ?? 0)
         ? html` <span class="individual-bottom individual-right-bottom">
-            ${individualObj?.showDirection
+            ${shouldShowDirection
               ? html`<ha-icon
                   class="small"
-                  .icon=${individualObj.invertAnimation ? "mdi:arrow-down" : "mdi:arrow-up"}
+                  .icon=${individualObj.invertAnimation ? "mdi:arrow-up" : "mdi:arrow-down"}
                 ></ha-icon>`
               : nothing}${displayState}
           </span>`
         : nothing}
     </div>
     <span class="label">${individualObj.name}</span>
-    ${showLine(config, individualObj.state || 0) && !config.entities.home?.hide
+    ${showLine(config, individualAbsState) && !config.entities.home?.hide
       ? html`
           <div class="right-individual-flow-container">
             <svg
@@ -98,13 +101,12 @@ export const individualRightBottomElement = (
             >
               <path
                 id="individual-bottom-right-home"
-                class="${styleLine(individualObj.state || 0, config)}"
+                class="${styleLine(individualAbsState, config)}"
                 d="M45,100 v-15 c0,-30 -10,-30 -30,-30 h-20"
                 vector-effect="non-scaling-stroke"
               />
               ${checkShouldShowDots(config) &&
-              individualObj.state &&
-              individualObj.state >= (individualObj.displayZeroTolerance ?? 0)
+              individualAbsState > (individualObj.displayZeroTolerance ?? 0)
                 ? svg`<circle r="1" class="individual-bottom" vector-effect="non-scaling-stroke">
                       <animateMotion
                         dur="${computeIndividualFlowRate(

--- a/packages/shared/src/components/individual-right-top-element.ts
+++ b/packages/shared/src/components/individual-right-top-element.ts
@@ -32,11 +32,14 @@ export const individualRightTopElement = (
   const disableEntityClick = config.clickable_entities === false;
 
   const indexOfIndividual = config?.entities?.individual?.findIndex(
-    (e) => e.entity === individualObj.entity
+    (e) => e === individualObj.field
   );
   if (indexOfIndividual === -1 || indexOfIndividual === undefined) return spacer;
 
   const duration = newDur.individual[indexOfIndividual] || 1.66;
+  const individualAbsState = Math.abs(individualObj.state || 0);
+  const shouldShowDirection =
+    individualObj?.showDirection && individualAbsState > (individualObj.displayZeroTolerance ?? 0);
 
   const hasBottomRow = !!battery?.has || checkHasBottomIndividual(individualObjs);
 
@@ -79,18 +82,18 @@ export const individualRightTopElement = (
         ? html` <ha-icon id="individual-right-top-icon" .icon=${individualObj.icon}></ha-icon>`
         : nothing}
       ${individualObj?.field?.display_zero_state !== false ||
-      (individualObj.state || 0) > (individualObj.displayZeroTolerance ?? 0)
+      individualAbsState > (individualObj.displayZeroTolerance ?? 0)
         ? html` <span class="individual-top individual-right-top">
-            ${individualObj?.showDirection
+            ${shouldShowDirection
               ? html`<ha-icon
                   class="small"
-                  .icon=${individualObj.invertAnimation ? "mdi:arrow-down" : "mdi:arrow-up"}
+                  .icon=${individualObj.invertAnimation ? "mdi:arrow-up" : "mdi:arrow-down"}
                 ></ha-icon>`
               : nothing}${displayState}
           </span>`
         : nothing}
     </div>
-    ${showLine(config, individualObj.state || 0) && !config.entities.home?.hide
+    ${showLine(config, individualAbsState) && !config.entities.home?.hide
       ? html`
           <div class="right-individual-flow-container">
             <svg
@@ -101,15 +104,14 @@ export const individualRightTopElement = (
             >
               <path
                 id="individual-top-right-home"
-                class="${styleLine(individualObj.state || 0, config)}"
+                class="${styleLine(individualAbsState, config)}"
                 d="M${hasBottomRow ? 45 : 47},0 v15 c0,${hasBottomRow
                   ? "30 -10,30 -30,30"
                   : "35 -10,35 -30,35"} h-20"
                 vector-effect="non-scaling-stroke"
               />
               ${checkShouldShowDots(config) &&
-              individualObj.state &&
-              individualObj.state >= (individualObj.displayZeroTolerance ?? 0)
+              individualAbsState > (individualObj.displayZeroTolerance ?? 0)
                 ? svg`<circle r="1" class="individual-top" vector-effect="non-scaling-stroke">
                       <animateMotion
                         dur="${computeIndividualFlowRate(

--- a/packages/shared/src/states/raw/individual/get-individual-object.ts
+++ b/packages/shared/src/states/raw/individual/get-individual-object.ts
@@ -84,14 +84,17 @@ export const getIndividualObject = ({
   field: IndividualDeviceType | undefined;
 }): IndividualObject => {
   if (!field || !field?.entity) return fallbackIndividualObject;
-  const entity = field.entity;
+  const entity =
+    typeof field.entity === "string"
+      ? field.entity
+      : field.entity.consumption || field.entity.production || "";
   const state = getIndividualState({ hass, config, energyGrowthMap, useDateSelection, field });
   const displayZero = field?.display_zero || false;
   const displayZeroTolerance = field?.display_zero_tolerance || 0;
   const has = hasIndividualObject(displayZero, state, displayZeroTolerance);
-  const isStateNegative = state && state < 0;
+  const isStatePositive = state && state > 0;
   const userConfiguredInvertAnimation = field?.inverted_animation || false;
-  const invertAnimation = isStateNegative
+  const invertAnimation = isStatePositive
     ? !userConfiguredInvertAnimation
     : userConfiguredInvertAnimation;
 

--- a/packages/shared/src/states/raw/individual/index.ts
+++ b/packages/shared/src/states/raw/individual/index.ts
@@ -20,17 +20,28 @@ export const getIndividualState = ({
   field: IndividualDeviceType;
 }) => {
   const energyCard = isEnergyCard(config);
-  const entity: string = field?.entity;
+  const entity = field?.entity;
 
   if (entity === undefined) return null;
 
   if (energyCard) {
-    return Math.abs(getEnergyEntityState(hass, energyGrowthMap, useDateSelection, entity));
+    if (typeof entity === "string") {
+      return Math.abs(getEnergyEntityState(hass, energyGrowthMap, useDateSelection, entity));
+    }
+
+    return Math.abs(
+      getEnergyEntityState(hass, energyGrowthMap, useDateSelection, entity.consumption)
+    );
   }
 
-  const individualStateWatts = getEntityStateWatts(hass, entity);
+  if (typeof entity === "string") {
+    return getEntityStateWatts(hass, entity);
+  }
 
-  return Math.abs(individualStateWatts);
+  const consumption = Math.abs(getEntityStateWatts(hass, entity.consumption));
+  const production = Math.abs(getEntityStateWatts(hass, entity.production));
+
+  return consumption - production;
 };
 
 export const getIndividualSecondaryState = (hass: HomeAssistant, field: IndividualDeviceType) => {

--- a/packages/shared/src/style/all.ts
+++ b/packages/shared/src/style/all.ts
@@ -18,7 +18,13 @@ type DynamicStylesInput = {
   grid: any;
   solar: any;
   entities: any;
-  individual: Array<{ has?: boolean; field?: IndividualDeviceType }>;
+  individual: Array<{
+    has?: boolean;
+    field?: IndividualDeviceType;
+    invertAnimation?: boolean;
+    state?: number | null;
+    displayZeroTolerance?: number;
+  }>;
   battery: any;
   homeSources: Record<string, { color: string }>;
   homeLargestSource: string;
@@ -275,8 +281,8 @@ export const allDynamicStyles = (main: HostWithStyle, input: DynamicStylesInput)
   }
 
   if (individual?.some((ind) => ind.has)) {
+    const colors = ["#d0cc5b", "#964cb5", "#b54c9d", "#5bd0cc"];
     const getStylesForIndividual = (field: IndividualDeviceType, index: number) => {
-      const colors = ["#d0cc5b", "#964cb5", "#b54c9d", "#5bd0cc"];
       const fieldNames = ["left-top", "left-bottom", "right-top", "right-bottom"];
 
       const fieldName = fieldNames[index] || "left-top";
@@ -317,5 +323,19 @@ export const allDynamicStyles = (main: HostWithStyle, input: DynamicStylesInput)
       if (!individualShown) continue;
       getStylesForIndividual(individualShown.field || {}, index);
     }
+    const homeIndividualIndex = individualsShown.findIndex(
+      (individualShown) =>
+        individualShown?.invertAnimation &&
+        Math.abs(individualShown.state || 0) > (individualShown.displayZeroTolerance ?? 0)
+    );
+    const homeIndividual = individualsShown[homeIndividualIndex];
+    let homeIndividualColor = homeIndividual?.field?.color;
+    if (typeof homeIndividualColor === "object") {
+      homeIndividualColor = convertColorListToHex(homeIndividualColor);
+    }
+    main.style.setProperty(
+      "--home-individual-color",
+      homeIndividualColor || colors[homeIndividualIndex] || "#d0cc5b"
+    );
   }
 };

--- a/packages/shared/src/style/index.ts
+++ b/packages/shared/src/style/index.ts
@@ -486,6 +486,11 @@ export const styles = css`
     stroke-width: 4;
     fill: var(--energy-grid-consumption-color);
   }
+  circle.individual-home {
+    stroke: var(--home-individual-color);
+    stroke-width: 4;
+    fill: var(--home-individual-color);
+  }
   .grid ha-icon:not(.small) {
     color: var(--icon-grid-color);
   }

--- a/packages/shared/src/types/type.ts
+++ b/packages/shared/src/types/type.ts
@@ -75,7 +75,7 @@ export type GridPowerOutage = {
 };
 
 export type IndividualDeviceType = BaseConfigEntity & {
-  entity: string;
+  entity: string | ComboEntity;
   color?: string;
   color_icon?: boolean;
   inverted_animation?: boolean;
@@ -120,6 +120,10 @@ export type HomeSources = {
     color: string;
   };
   gridNonFossil: {
+    value: number;
+    color: string;
+  };
+  individual?: {
     value: number;
     color: string;
   };

--- a/packages/shared/src/ui-editor/components/individual-devices-editor.ts
+++ b/packages/shared/src/ui-editor/components/individual-devices-editor.ts
@@ -2,7 +2,6 @@ import localize from "@flixlix-cards/shared/i18n";
 import {
   type EditSubElementEvent,
   type IndividualDeviceType,
-  type LovelaceRowConfig,
   type PowerFlowCardPlusConfig,
   type SubElementEditorConfig,
 } from "@flixlix-cards/shared/types";
@@ -29,7 +28,7 @@ export class IndividualDevicesEditor extends LitElement {
 
   @state() private _subElementEditorConfig?: SubElementEditorConfig;
 
-  @state() private _configEntities?: LovelaceRowConfig[];
+  @state() private _configEntities?: IndividualDeviceType[];
 
   protected render(): TemplateResult {
     if (!this.config || !this.hass) {

--- a/packages/shared/src/ui-editor/components/individual-row-editor.ts
+++ b/packages/shared/src/ui-editor/components/individual-row-editor.ts
@@ -1,8 +1,7 @@
 import localize from "@flixlix-cards/shared/i18n";
 import {
   type EditSubElementEvent,
-  type EntityConfig,
-  type LovelaceRowConfig,
+  type IndividualDeviceType,
   type PowerFlowCardPlusConfig,
 } from "@flixlix-cards/shared/types";
 import { fireEvent } from "@flixlix-cards/shared/ui-editor/utils/fire-event";
@@ -23,7 +22,7 @@ import { individualSchema } from "../schema/individual";
 declare global {
   interface HASSDomEvents {
     "entities-changed": {
-      entities: LovelaceRowConfig[];
+      entities: IndividualDeviceType[];
     };
     "edit-detail-element": EditSubElementEvent;
   }
@@ -33,18 +32,20 @@ declare global {
   }
 }
 
+type IndividualEditorRow = IndividualDeviceType & { type?: string };
+
 export class IndividualRowEditor extends LitElement {
   @property({ attribute: false }) protected hass?: HomeAssistant;
 
   @property({ attribute: false }) protected config?: PowerFlowCardPlusConfig;
 
-  @property({ attribute: false }) protected entities?: LovelaceRowConfig[];
+  @property({ attribute: false }) protected entities?: IndividualEditorRow[];
 
   @property() protected label?: string;
 
   @state() protected _indexBeingEdited: number = -1;
 
-  private _entityKeys = new WeakMap<LovelaceRowConfig, string>();
+  private _entityKeys = new WeakMap<IndividualEditorRow, string>();
 
   private _sortable?: SortableInstance;
 
@@ -62,7 +63,7 @@ export class IndividualRowEditor extends LitElement {
     this._indexBeingEdited = index;
   }
 
-  private _getKey(action: LovelaceRowConfig) {
+  private _getKey(action: IndividualEditorRow) {
     if (!this._entityKeys.has(action)) {
       this._entityKeys.set(action, Math.random().toString());
     }
@@ -130,7 +131,9 @@ export class IndividualRowEditor extends LitElement {
                       allow-custom-entity
                       hideClearIcon
                       .hass=${this.hass}
-                      .value=${(entityConf as EntityConfig).entity}
+                      .value=${typeof entityConf.entity === "string"
+                        ? entityConf.entity
+                        : entityConf.entity.consumption || entityConf.entity.production}
                       .index=${index}
                       @value-changed=${this._valueChanged}
                     ></ha-entity-picker>
@@ -284,7 +287,7 @@ export class IndividualRowEditor extends LitElement {
       subElementConfig: {
         index,
         type: "row",
-        elementConfig: this.entities![index],
+        elementConfig: this.entities![index] as any,
       },
     });
   }

--- a/packages/shared/src/ui-editor/schema/individual.ts
+++ b/packages/shared/src/ui-editor/schema/individual.ts
@@ -1,5 +1,11 @@
 import localize from "@flixlix-cards/shared/i18n";
-import { actionSchema, getBaseMainConfigSchema, secondaryInfoSchema } from "./_schema-base";
+import {
+  actionSchema,
+  getBaseMainConfigSchema,
+  getEntityCombinedSelectionSchema,
+  getEntitySeparatedSelectionSchema,
+  secondaryInfoSchema,
+} from "./_schema-base";
 
 const mainSchema = {
   ...getBaseMainConfigSchema(),
@@ -74,10 +80,8 @@ const mainSchema = {
 };
 
 export const individualSchema = [
-  {
-    name: "entity",
-    selector: { entity: {} },
-  },
+  getEntityCombinedSelectionSchema(),
+  getEntitySeparatedSelectionSchema(),
   mainSchema,
   {
     name: "color",


### PR DESCRIPTION
## Summary

Allow individual devices in `power-flow-card-plus` to use negative power values, so bidirectional devices like an EcoFlow battery can show reversed flow direction.

## What changed

- Preserve signed power values for individual devices in the power card.
- Keep negative individual values visible by using absolute values only for line visibility and flow-rate calculations.
- Reverse the individual flow animation when the value is negative.
- Keep energy-card individual values unchanged, where absolute values are still used.
- Update the regression test for negative individual power values.

## Testing

- `pnpm --filter power-flow-card-plus test`
- `pnpm --filter @flixlix-cards/shared test`
- `pnpm --filter power-flow-card-plus typecheck`
- `pnpm --filter @flixlix-cards/shared typecheck`
- `pnpm --filter power-flow-card-plus format:check`
- `pnpm --filter @flixlix-cards/shared format:check`
- `pnpm --filter power-flow-card-plus lint`
- `pnpm --filter @flixlix-cards/shared lint`