### PR TITLE
Fix: Make the power flow dot speed feel linear with power

### DIFF
--- a/.changeset/flow-rate-speed-linearity.md
+++ b/.changeset/flow-rate-speed-linearity.md
@@ -1,0 +1,19 @@
+---
+"power-flow-card-plus": minor
+"energy-flow-card-plus": minor
+---
+
+Fix: the new flow rate model now interpolates dot speed instead of dot duration
+
+`min_flow_rate` and `max_flow_rate` are animation durations, but perceived speed is
+their reciprocal, so interpolating the duration linearly against power produced a
+hyperbolic speed response. With the default 6s..0.75s range a line running at 90% of
+`max_expected_power` animated at only 59% of the top speed, and everything below
+roughly half power collapsed into an indistinguishable crawl.
+
+The endpoints are unchanged — `min_expected_power` still maps to `max_flow_rate` and
+`max_expected_power` to `min_flow_rate` — but values in between now animate at a speed
+that tracks the reading linearly. Values below `min_expected_power` are also clamped to
+`max_flow_rate`; previously they produced a duration slower than the configured maximum.
+
+The old flow rate model (`use_new_flow_rate_model: false`) is unaffected.

--- a/.changeset/numeric-calculate-flow-rate.md
+++ b/.changeset/numeric-calculate-flow-rate.md
@@ -1,0 +1,12 @@
+---
+"power-flow-card-plus": patch
+"energy-flow-card-plus": patch
+---
+
+Fix: `calculate_flow_rate` set to a number is now honoured
+
+A numeric `calculate_flow_rate` is documented to pin a line's dot to that many
+seconds per traverse, but the value was silently ignored and the computed flow rate
+was used instead. Numbers now take precedence, as documented. Setting `true` or
+leaving the option unset keeps using the computed flow rate, and `false` still pins
+the dot to the 1.66s default.

--- a/packages/shared/__tests__/core-utils.test.ts
+++ b/packages/shared/__tests__/core-utils.test.ts
@@ -37,7 +37,20 @@ describe("core utils", () => {
     expect(computeFlowRate(config, 101, 0)).toBe(1);
   });
 
-  test("computeFlowRate (new model) maps min/max linearly", () => {
+  test("computeFlowRate (new model) clamps below min_expected_power", () => {
+    const config = {
+      max_expected_power: 100,
+      min_expected_power: 20,
+      max_flow_rate: 10,
+      min_flow_rate: 1,
+      use_new_flow_rate_model: true,
+    } as unknown as FlowCardPlusConfig;
+
+    expect(computeFlowRate(config, 0, 0)).toBe(10);
+    expect(computeFlowRate(config, 20, 0)).toBe(10);
+  });
+
+  test("computeFlowRate (new model) preserves the min/max endpoints", () => {
     const config = {
       max_expected_power: 100,
       min_expected_power: 0,
@@ -48,7 +61,39 @@ describe("core utils", () => {
 
     expect(computeFlowRate(config, 0, 0)).toBe(10);
     expect(computeFlowRate(config, 100, 0)).toBe(1);
-    expect(computeFlowRate(config, 50, 0)).toBeCloseTo(5.5, 10);
+  });
+
+  test("computeFlowRate (new model) maps dot speed linearly, not duration", () => {
+    const config = {
+      max_expected_power: 100,
+      min_expected_power: 0,
+      max_flow_rate: 10,
+      min_flow_rate: 1,
+      use_new_flow_rate_model: true,
+    } as unknown as FlowCardPlusConfig;
+
+    // Speed is 1 / duration, so the midpoint sits halfway between 1/10 and 1/1.
+    expect(computeFlowRate(config, 50, 0)).toBeCloseTo(1 / 0.55, 10);
+
+    const speedAt = (value: number) => 1 / computeFlowRate(config, value, 0);
+    const slowest = speedAt(0);
+    const fastest = speedAt(100);
+    for (const fraction of [0.1, 0.25, 0.5, 0.75, 0.9]) {
+      expect(speedAt(fraction * 100)).toBeCloseTo(slowest + fraction * (fastest - slowest), 10);
+    }
+  });
+
+  test("computeFlowRate (new model) survives a zeroed min_flow_rate", () => {
+    const config = {
+      max_expected_power: 100,
+      min_expected_power: 0,
+      max_flow_rate: 10,
+      min_flow_rate: 0,
+      use_new_flow_rate_model: true,
+    } as unknown as FlowCardPlusConfig;
+
+    expect(computeFlowRate(config, 50, 0)).toBeGreaterThan(0);
+    expect(Number.isFinite(computeFlowRate(config, 50, 0))).toBe(true);
   });
 
   test("computeFlowRate (old model) uses total when provided", () => {

--- a/packages/shared/__tests__/core-utils.test.ts
+++ b/packages/shared/__tests__/core-utils.test.ts
@@ -116,6 +116,11 @@ describe("core utils", () => {
     expect(computeIndividualFlowRate(3.3, undefined)).toBe(3.3);
   });
 
+  test("computeIndividualFlowRate prefers a numeric entry over the computed value", () => {
+    expect(computeIndividualFlowRate(10, 2.5)).toBe(10);
+    expect(computeIndividualFlowRate(0, 2.5)).toBe(0);
+  });
+
   test("computeIndividualFlowRate returns default when entry is false", () => {
     expect(computeIndividualFlowRate(false, 2.5)).toBe(1.66);
   });

--- a/packages/shared/src/components/individual-left-bottom-element.ts
+++ b/packages/shared/src/components/individual-left-bottom-element.ts
@@ -45,7 +45,7 @@ export const individualLeftBottomElement = (
               ? svg`<circle r="1.75" class="individual-bottom" vector-effect="non-scaling-stroke">
                     <animateMotion
                       dur="${computeIndividualFlowRate(
-                        individualObj.field?.calculate_flow_rate !== false,
+                        individualObj.field?.calculate_flow_rate,
                         duration
                       )}s"
                       repeatCount="indefinite"

--- a/packages/shared/src/utils/compute-flow-rate.ts
+++ b/packages/shared/src/utils/compute-flow-rate.ts
@@ -62,11 +62,11 @@ export const computeFlowRate = (
 };
 
 export const computeIndividualFlowRate = (entry?: boolean | number, value?: number): number => {
-  if (entry !== false && value) {
-    return value;
-  }
   if (typeof entry === "number") {
     return entry;
+  }
+  if (entry !== false && value) {
+    return value;
   }
   return 1.66;
 };

--- a/packages/shared/src/utils/compute-flow-rate.ts
+++ b/packages/shared/src/utils/compute-flow-rate.ts
@@ -1,22 +1,41 @@
 import { type FlowCardPlusConfig } from "@flixlix-cards/shared/types";
 
-const newFlowRateMapRange = (
-  value: number,
-  minOut: number,
-  maxOut: number,
-  minIn: number,
-  maxIn: number
-): number => {
-  if (value > maxIn) return maxOut;
-  return ((value - minIn) * (maxOut - minOut)) / (maxIn - minIn) + minOut;
-};
+/**
+ * Lower bound for an animation duration, in seconds. Guards the reciprocal
+ * arithmetic below against a config that sets a flow rate to 0.
+ */
+const MIN_DURATION = 0.01;
 
+const clamp = (value: number, min: number, max: number): number =>
+  Math.min(Math.max(value, min), max);
+
+/**
+ * Maps a power/energy value onto an animation duration, in seconds.
+ *
+ * The interpolation happens in *speed* space (1 / duration) rather than in
+ * duration space. Duration is what the SVG `animateMotion` consumes, but speed
+ * is what the eye actually reads, and the two are reciprocals. Interpolating
+ * the duration linearly therefore produces a hyperbolic speed response: with
+ * the default 6s..0.75s range, a line running at 90% of `max_expected_power`
+ * renders at only 59% of the top speed, and everything below roughly half power
+ * collapses into an indistinguishable crawl.
+ *
+ * Interpolating the reciprocal keeps the same endpoints while making the
+ * perceived dot speed track the value linearly.
+ */
 const newFlowRate = (config: FlowCardPlusConfig, value: number): number => {
   const maxPower = config.max_expected_power;
   const minPower = config.min_expected_power;
-  const maxRate = config.max_flow_rate;
-  const minRate = config.min_flow_rate;
-  return newFlowRateMapRange(value, maxRate, minRate, minPower, maxPower);
+  const slowest = Math.max(config.max_flow_rate, MIN_DURATION);
+  const fastest = Math.max(config.min_flow_rate, MIN_DURATION);
+
+  // Values above max_expected_power clamp to the fastest speed, values below
+  // min_expected_power to the slowest.
+  const progress = clamp((value - minPower) / (maxPower - minPower), 0, 1);
+
+  const slowestSpeed = 1 / slowest;
+  const fastestSpeed = 1 / fastest;
+  return 1 / (slowestSpeed + progress * (fastestSpeed - slowestSpeed));
 };
 
 const oldFlowRate = (config: FlowCardPlusConfig, value: number, total: number): number => {


### PR DESCRIPTION
The dots in the new flow rate model behave oddly. They move at full speed once you're at or above `max_expected_power`, but drop off a cliff just below it, and anything under about half power looks like the same slow crawl.

The cause is that `min_flow_rate` and `max_flow_rate` are durations, and get passed straight into `<animateMotion dur="...">`. But what you perceive is speed, which is 1/duration. `newFlowRate` interpolates the duration linearly against
power, so the speed curve comes out as a hyperbola.

Proposed fix: interpolate 1/duration instead of duration. With the stock defaults (6s..0.75s,`max_expected_power: 2000`):

| power | % of max | dot speed before | after |
|------:|---------:|-----------------:|------:|
| 2000 W | 100% | 100% | 100% |
| 1800 W |  90% |  59% |  91% |
| 1500 W |  75% |  36% |  78% |
| 1000 W |  50% |  22% |  56% |
|  500 W |  25% |  16% |  34% |
|  100 W |   5% |  13% |  17% |

Dropping from 100% to 90% of max used to drop by 41% of the visible speed, and the whole bottom half of the range was a 13-22% band.

Two things fixed in the same function. Values below `min_expected_power` now clamp; before they produced a duration slower than `max_flow_rate`. And the reciprocal is guarded in case someone sets a flow rate to 0.

The old model (`use_new_flow_rate_model: false`) is untouched.

### Second commit: numeric calculate_flow_rate

Found this while tracing the above. `calculate_flow_rate: 10` is supposed to pin a line's dot to 10s per traverse, but `entry !== false && value` matches first and returns the computed rate, so the number is never reached. Swapped the order.

`individual-left-bottom-element` was also passing `!== false` rather than the raw config value. That made no difference before, since numbers were being swallowed anyway, but it would have left that one position stuck on the computed rate with this fix, so it is now aligned with the four other call sites.

### Testing

`packages/shared` is 68/68, with new tests for the linear speed property, the endpoints, the sub-minimum clamp, and a zeroed `min_flow_rate`. typecheck, lint and format:check are all clean.

Changesets are in: minor for the curve change, since it visibly changes the animation for everyone, and patch for `calculate_flow_rate`.