### PR TITLE
Fix additional info for more than 4 individual objects that are hidden

### DIFF
--- a/packages/flixlix-cards/energy-flow-card-plus/src/energy-flow-card-plus.ts
+++ b/packages/flixlix-cards/energy-flow-card-plus/src/energy-flow-card-plus.ts
@@ -1178,7 +1178,6 @@ export class EnergyFlowCardPlus extends LitElement {
     const homeLargestSource = homeSourceKeys.reduce((a, b) =>
       homeSources[a].value > homeSources[b].value ? a : b
     );
-    const individualKeys = ["left-top", "left-bottom", "right-top", "right-bottom"];
     const templatesObj: TemplatesObj = {
       gridSecondary: this._templateResults.gridSecondary?.result,
       solarSecondary: this._templateResults.solarSecondary?.result,
@@ -1186,7 +1185,7 @@ export class EnergyFlowCardPlus extends LitElement {
       nonFossilFuelSecondary: this._templateResults.nonFossilFuelSecondary?.result,
       individual:
         individualObjs?.map(
-          (_, index) => this._templateResults[`${individualKeys[index]}Secondary`]?.result
+          (_, index) => this._templateResults[`individual${index}Secondary`]?.result
         ) || [],
     };
 
@@ -1273,9 +1272,8 @@ export class EnergyFlowCardPlus extends LitElement {
     for (const [key, value] of Object.entries(templatesObj)) {
       if (value) {
         if (Array.isArray(value)) {
-          const individualKeys = ["left-top", "left-bottom", "right-top", "right-bottom"];
           value.forEach((template, index) => {
-            if (template) this._tryConnect(template, `${individualKeys[index]}Secondary`);
+            if (template) this._tryConnect(template, `individual${index}Secondary`);
           });
         } else {
           this._tryConnect(value, key);

--- a/packages/flixlix-cards/power-flow-card-plus/src/power-flow-card-plus.ts
+++ b/packages/flixlix-cards/power-flow-card-plus/src/power-flow-card-plus.ts
@@ -981,7 +981,6 @@ export class PowerFlowCardPlus extends LitElement {
     const homeLargestSource = homeSourceKeys.reduce((a, b) =>
       homeSources[a].value > homeSources[b].value ? a : b
     );
-    const individualKeys = ["left-top", "left-bottom", "right-top", "right-bottom"];
     const templatesObj: TemplatesObj = {
       gridSecondary: this._templateResults.gridSecondary?.result,
       solarSecondary: this._templateResults.solarSecondary?.result,
@@ -989,7 +988,7 @@ export class PowerFlowCardPlus extends LitElement {
       nonFossilFuelSecondary: this._templateResults.nonFossilFuelSecondary?.result,
       individual:
         individualObjs?.map(
-          (_, index) => this._templateResults[`${individualKeys[index]}Secondary`]?.result
+          (_, index) => this._templateResults[`individual${index}Secondary`]?.result
         ) || [],
     };
 
@@ -1076,9 +1075,8 @@ export class PowerFlowCardPlus extends LitElement {
     for (const [key, value] of Object.entries(templatesObj)) {
       if (value) {
         if (Array.isArray(value)) {
-          const individualKeys = ["left-top", "left-bottom", "right-top", "right-bottom"];
           value.forEach((template, index) => {
-            if (template) this._tryConnect(template, `${individualKeys[index]}Secondary`);
+            if (template) this._tryConnect(template, `individual${index}Secondary`);
           });
         } else {
           this._tryConnect(value, key);


### PR DESCRIPTION
When you have more than four individual objects defined, of which some of them are hidden, the additional info displayed the ones that are displayed is wrong / duplicate, as some will get a "undefined" index. So multiple UI elements have the same ID.

<img width="213" height="357" alt="SNAG-20260807-11" src="https://github.com/user-attachments/assets/db79cbc2-9c06-4820-8b14-f080579aee4b" />
