### PR TITLE
fix: animate vertical individual flows with CSS on WebKit

### DIFF
--- a/.changeset/fix-ipad-individual-motion.md
+++ b/.changeset/fix-ipad-individual-motion.md
@@ -1,0 +1,6 @@
+---
+"energy-flow-card-plus": patch
+"power-flow-card-plus": patch
+---
+
+Replace the first two individual flows' SVG SMIL animations with CSS transform animations for iPad and WebKit compatibility.

--- a/packages/flixlix-cards/power-flow-card-plus/__tests__/render.test.ts
+++ b/packages/flixlix-cards/power-flow-card-plus/__tests__/render.test.ts
@@ -91,6 +91,54 @@ describe("render", () => {
     const rendered = (card as unknown as { render: () => unknown }).render();
     expect(rendered).toBeTruthy();
   });
+
+  test("animates the first two individuals with CSS instead of SVG animateMotion", async () => {
+    const config = {
+      type: "custom:power-flow-card-plus",
+      entities: {
+        grid: { entity: "sensor.grid" },
+        individual: [
+          { entity: "sensor.gas", inverted_animation: true },
+          { entity: "sensor.water", inverted_animation: true },
+        ],
+      },
+    } as PowerFlowCardPlusConfig;
+    const card = new PowerFlowCardPlus();
+    card.setConfig(config);
+    card.hass = makeHass({
+      "sensor.grid": "100",
+      "sensor.gas": "20",
+      "sensor.water": "10",
+    });
+    document.body.append(card);
+    await card.updateComplete;
+
+    const visiblePath = card.shadowRoot?.querySelector("#individual-top");
+    const individualSvg = visiblePath?.closest("svg");
+    const motionDot = individualSvg?.querySelector(".individual-left-top-motion-dot");
+    expect(visiblePath?.getAttribute("d")).toBe("M40 -10 v50");
+    expect(motionDot?.getAttribute("cx")).toBe("40");
+    expect(motionDot?.getAttribute("cy")).toBe("-10");
+    expect(motionDot?.getAttribute("style")).toContain("animation-duration:");
+    expect(motionDot?.classList.contains("forward")).toBe(true);
+    expect(individualSvg?.querySelector("animateMotion")).toBeNull();
+    expect(individualSvg?.querySelector("mpath")).toBeNull();
+
+    const visibleBottomPath = card.shadowRoot?.querySelector("#individual-bottom");
+    const bottomIndividualSvg = visibleBottomPath?.closest("svg");
+    const bottomMotionDot = bottomIndividualSvg?.querySelector(
+      ".individual-left-bottom-motion-dot"
+    );
+    expect(visibleBottomPath?.getAttribute("d")).toBe("M40 40 v-40");
+    expect(bottomMotionDot?.getAttribute("cx")).toBe("40");
+    expect(bottomMotionDot?.getAttribute("cy")).toBe("40");
+    expect(bottomMotionDot?.getAttribute("style")).toContain("animation-duration:");
+    expect(bottomMotionDot?.classList.contains("forward")).toBe(true);
+    expect(bottomIndividualSvg?.querySelector("animateMotion")).toBeNull();
+    expect(bottomIndividualSvg?.querySelector("mpath")).toBeNull();
+
+    card.remove();
+  });
 });
 
 describe("_computeRenderData", () => {

--- a/packages/shared/src/components/individual-left-bottom-element.ts
+++ b/packages/shared/src/components/individual-left-bottom-element.ts
@@ -30,32 +30,32 @@ export const individualLeftBottomElement = (
   const indexOfIndividual =
     config?.entities?.individual?.findIndex((e) => e.entity === individualObj.entity) || 0;
   const duration = newDur.individual[indexOfIndividual] || 0;
+  const motionPath = "M40 40 v-40";
+  const animationDuration = computeIndividualFlowRate(
+    individualObj.field?.calculate_flow_rate !== false,
+    duration
+  );
+  const animationDirectionClass = individualObj.invertAnimation ? "forward" : "reverse";
   return html`<div class="circle-container individual-bottom bottom">
     ${showLine(config, individualObj?.state || 0) && !config.entities.home?.hide
       ? html`
           <svg width="80" height="30">
             <path
-              d="M40 40 v-40"
+              d=${motionPath}
               id="individual-bottom"
               class="${styleLine(individualObj?.state || 0, config)}"
             />
             ${checkShouldShowDots(config) &&
             individualObj?.state &&
             individualObj.state >= (individualObj.displayZeroTolerance ?? 0)
-              ? svg`<circle r="1.75" class="individual-bottom" vector-effect="non-scaling-stroke">
-                    <animateMotion
-                      dur="${computeIndividualFlowRate(
-                        individualObj.field?.calculate_flow_rate !== false,
-                        duration
-                      )}s"
-                      repeatCount="indefinite"
-                      calcMode="paced"
-                      keyPoints="${individualObj.invertAnimation ? "0;1" : "1;0"}"
-                      keyTimes="0;1"
-                    >
-                      <mpath xlink:href="#individual-bottom" />
-                    </animateMotion>
-                  </circle>`
+              ? svg`<circle
+                    cx="40"
+                    cy="40"
+                    r="1.75"
+                    class="individual-bottom individual-left-bottom-motion-dot ${animationDirectionClass}"
+                    vector-effect="non-scaling-stroke"
+                    style="${`animation-duration: ${animationDuration}s`}"
+                  ></circle>`
               : nothing}
           </svg>
         `

--- a/packages/shared/src/components/individual-left-top-element.ts
+++ b/packages/shared/src/components/individual-left-top-element.ts
@@ -30,6 +30,12 @@ export const individualLeftTopElement = (
   const indexOfIndividual =
     config?.entities?.individual?.findIndex((e) => e.entity === individualObj.entity) || 0;
   const duration = newDur.individual[indexOfIndividual] || 0;
+  const motionPath = "M40 -10 v50";
+  const animationDuration = computeIndividualFlowRate(
+    individualObj?.field?.calculate_flow_rate,
+    duration
+  );
+  const animationDirectionClass = individualObj.invertAnimation ? "forward" : "reverse";
   return html`<div class="circle-container individual-top">
     <span class="label">${individualObj.name}</span>
     <div
@@ -84,27 +90,21 @@ export const individualLeftTopElement = (
       ? html`
           <svg width="80" height="30">
             <path
-              d="M40 -10 v50"
+              d=${motionPath}
               id="individual-top"
               class="${styleLine(individualObj.state || 0, config)}"
             />
             ${checkShouldShowDots(config) &&
             individualObj.state &&
             individualObj.state >= (individualObj.displayZeroTolerance ?? 0)
-              ? svg`<circle r="1.75" class="individual-top" vector-effect="non-scaling-stroke">
-                    <animateMotion
-                      dur="${computeIndividualFlowRate(
-                        individualObj?.field?.calculate_flow_rate,
-                        duration
-                      )}s"
-                      repeatCount="indefinite"
-                      calcMode="paced"
-                      keyPoints="${individualObj.invertAnimation ? "0;1" : "1;0"}"
-                      keyTimes="0;1"
-                    >
-                      <mpath xlink:href="#individual-top" />
-                    </animateMotion>
-                  </circle>`
+              ? svg`<circle
+                    cx="40"
+                    cy="-10"
+                    r="1.75"
+                    class="individual-top individual-left-top-motion-dot ${animationDirectionClass}"
+                    vector-effect="non-scaling-stroke"
+                    style="${`animation-duration: ${animationDuration}s`}"
+                  ></circle>`
               : nothing}
           </svg>
         `

--- a/packages/shared/src/style/index.ts
+++ b/packages/shared/src/style/index.ts
@@ -306,6 +306,40 @@ export const styles = css`
     width: var(--dot-size);
     fill: var(--individual-left-top-color);
   }
+  circle.individual-left-top-motion-dot {
+    animation-name: individual-left-top-motion;
+    animation-timing-function: linear;
+    animation-iteration-count: infinite;
+    animation-direction: reverse;
+  }
+  circle.individual-left-top-motion-dot.forward {
+    animation-direction: normal;
+  }
+  @keyframes individual-left-top-motion {
+    from {
+      transform: translateY(0);
+    }
+    to {
+      transform: translateY(50px);
+    }
+  }
+  circle.individual-left-bottom-motion-dot {
+    animation-name: individual-left-bottom-motion;
+    animation-timing-function: linear;
+    animation-iteration-count: infinite;
+    animation-direction: reverse;
+  }
+  circle.individual-left-bottom-motion-dot.forward {
+    animation-direction: normal;
+  }
+  @keyframes individual-left-bottom-motion {
+    from {
+      transform: translateY(0);
+    }
+    to {
+      transform: translateY(-40px);
+    }
+  }
   circle.individual-bottom {
     stroke-width: 4;
     width: var(--dot-size);


### PR DESCRIPTION
## Summary

- replace the SVG SMIL `animateMotion`/`mpath` dots on the first two vertical individual flows with CSS transform animations
- preserve the computed flow duration and `inverted_animation` direction
- explicitly position each SVG dot so WebKit cannot leave it clipped at the SVG origin
- add regression coverage and patch changesets for both flow cards

## Why

On affected iPads, WebKit does not run these individual `animateMotion` elements. The circles remain at their default `(0, 0)` position, where SVG clipping makes them appear as stationary quarter circles beside the actual flow lines.

## Validation

- reproduced with Energy Flow Card Plus 0.2.3 in Home Assistant 2026.6.3
- manually verified the top individual flow on a real iPad after deploying the production bundle
- regression test covers both vertical individual positions with `inverted_animation: true`
- `pnpm --filter @flixlix-cards/shared typecheck`
- `pnpm --filter power-flow-card-plus typecheck`
- `pnpm --filter energy-flow-card-plus typecheck`
- `pnpm --filter power-flow-card-plus test`
- `pnpm --filter energy-flow-card-plus test`
- production Rollup builds for both cards

Fixes #274
